### PR TITLE
All comparisons with floats now use float literals (except 0)

### DIFF
--- a/inc/el_producer.hpp
+++ b/inc/el_producer.hpp
@@ -21,6 +21,11 @@ public:
   const float ElectronMiniIsoCut = 0.1;
   const float ElectronRelIsoCut = 0.35;
 
+  const float dxyCut = 0.5;
+  const float dzCut = 1.0;
+  const float jetDRCut = 0.4;
+  const float jetpTCut = 1.0;
+
   std::vector<int> WriteElectrons(nano_tree &nano, pico_tree &pico, 
                                   std::vector<int> &jet_islep_nano_idx, 
                                   std::vector<int> &jet_isvlep_nano_idx, 

--- a/inc/mu_producer.hpp
+++ b/inc/mu_producer.hpp
@@ -21,6 +21,10 @@ public:
   const float MuonEtaCut        = 2.4;
   const float MuonMiniIsoCut    = 0.2;
   const float MuonRelIsoCut     = 0.35;
+  const float dzCut         = 0.1;
+  const float dxyCut        = 0.5;
+  const float MuonHighPt        = 200;
+  const float MuonSip3dCut      = 4.0;
 
   std::vector<int> WriteMuons(nano_tree &nano, pico_tree &pico, std::vector<int> &jet_islep_nano_idx, std::vector<int> &jet_isvlep_nano_idx, std::vector<int> &sig_mu_pico_idx, bool isZgamma, bool isFastsim);
 

--- a/src/el_producer.cpp
+++ b/src/el_producer.cpp
@@ -56,8 +56,8 @@ bool ElectronProducer::IsSignal(nano_tree &nano, int nano_idx, bool isZgamma) {
   if (isZgamma) {
     if (pt <= ZgElectronPtCut) return false;
     if (fabs(etasc) > ElectronEtaCut) return false;
-    if (fabs(dz) > 1.0) return false;
-    if (fabs(dxy) > 0.5) return false; 
+    if (fabs(dz) > dzCut) return false;
+    if (fabs(dxy) > dxyCut) return false; 
     switch(year) {
       case 2016:
       case 2017:
@@ -131,8 +131,8 @@ vector<int> ElectronProducer::WriteElectrons(nano_tree &nano, pico_tree &pico, v
     if(isZgamma) { // For Zgamma productions
       if (pt <= ZgElectronPtCut) continue;
       if (fabs(etasc) > ElectronEtaCut) continue;
-      if (fabs(dz) > 1.0)  continue;
-      if (fabs(dxy) > 0.5) continue; 
+      if (fabs(dz) > dzCut)  continue;
+      if (fabs(dxy) > dxyCut) continue; 
       isSignal = IsSignal(nano, iel, isZgamma);
       float scale_syst_up = 1.0;
       float scale_syst_dn = 1.0;
@@ -215,8 +215,8 @@ vector<int> ElectronProducer::WriteElectrons(nano_tree &nano, pico_tree &pico, v
       pico.out_nvlep()++;
       // save indices of matching jets
       for (int ijet(0); ijet<nano.nJet(); ijet++) {
-        if (dR(eta, nano.Jet_eta()[ijet], phi, nano.Jet_phi()[ijet])<0.4 &&
-            fabs(Jet_pt[ijet] - nano.Electron_pt()[iel])/nano.Electron_pt()[iel] < 1)
+        if (dR(eta, nano.Jet_eta()[ijet], phi, nano.Jet_phi()[ijet])<0.4f &&
+            fabs(Jet_pt[ijet] - nano.Electron_pt()[iel])/nano.Electron_pt()[iel] < 1f)
           jet_isvlep_nano_idx.push_back(ijet);
       }
     }
@@ -233,8 +233,8 @@ vector<int> ElectronProducer::WriteElectrons(nano_tree &nano, pico_tree &pico, v
       sig_el_pico_idx.push_back(pico_idx);
       // save indices of matching jets
       for (int ijet(0); ijet<nano.nJet(); ijet++) {
-        if (dR(eta, nano.Jet_eta()[ijet], phi, nano.Jet_phi()[ijet])<0.4 &&
-            fabs(Jet_pt[ijet] - nano.Electron_pt()[iel])/nano.Electron_pt()[iel] < 1)
+        if (dR(eta, nano.Jet_eta()[ijet], phi, nano.Jet_phi()[ijet])<jetDRCut &&
+            fabs(Jet_pt[ijet] - nano.Electron_pt()[iel])/nano.Electron_pt()[iel] < jetpTCut)
           jet_islep_nano_idx.push_back(ijet);
       }
     }

--- a/src/el_producer.cpp
+++ b/src/el_producer.cpp
@@ -77,8 +77,8 @@ bool ElectronProducer::IsSignal(nano_tree &nano, int nano_idx, bool isZgamma) {
     if (pt <= SignalElectronPtCut) return false;
     if (fabs(eta) > ElectronEtaCut) return false;
     if (!idElectron_noIso(bitmap, 1)) return false;
-    if ((isBarrel && fabs(dz)>0.10) || (!isBarrel && fabs(dz)>0.20)) return false;
-    if ((isBarrel && fabs(dxy)>0.05) || (!isBarrel && fabs(dxy)>0.10)) return false; 
+    if ((isBarrel && fabs(dz)>0.10f) || (!isBarrel && fabs(dz)>0.20f)) return false;
+    if ((isBarrel && fabs(dxy)>0.05f) || (!isBarrel && fabs(dxy)>0.10f)) return false; 
     return (id && miniiso < ElectronMiniIsoCut);
   }
   return false;
@@ -185,9 +185,9 @@ vector<int> ElectronProducer::WriteElectrons(nano_tree &nano, pico_tree &pico, v
       if (fabs(eta) > ElectronEtaCut) continue;
       int bitmap = nano.Electron_vidNestedWPBitmap()[iel];
       if (!idElectron_noIso(bitmap, 1)) continue;
-      bool isBarrel = fabs(eta) <= 1.479;
-      if ((isBarrel && fabs(dz)>0.10) || (!isBarrel && fabs(dz)>0.20)) continue;
-      if ((isBarrel && fabs(dxy)>0.05) || (!isBarrel && fabs(dxy)>0.10)) continue; 
+      bool isBarrel = fabs(eta) <= 1.479f;
+      if ((isBarrel && fabs(dz)>0.10f) || (!isBarrel && fabs(dz)>0.20f)) continue;
+      if ((isBarrel && fabs(dxy)>0.05f) || (!isBarrel && fabs(dxy)>0.10f)) continue; 
       isSignal = IsSignal(nano, iel, isZgamma);
       id = idElectron_noIso(bitmap,3);
     }

--- a/src/event_tools.cpp
+++ b/src/event_tools.cpp
@@ -99,15 +99,15 @@ void EventTools::WriteStitch(nano_tree &nano, pico_tree &pico){
   }
 
   if(isTTJets_LO_Incl && !isFastSim) {
-    if (nano.LHE_HTIncoming()>600) 
+    if (nano.LHE_HTIncoming()>600.f) 
       pico.out_stitch_htmet() = pico.out_stitch_ht() = false;
-    if(year==2018 && nano.GenMET_pt()>80)
+    if(year==2018 && nano.GenMET_pt()>80.f)
       pico.out_stitch_htmet() = pico.out_stitch() = false;
-    else if (nano.GenMET_pt()>150) 
+    else if (nano.GenMET_pt()>150.f) 
       pico.out_stitch_htmet() = pico.out_stitch() = false;
   }
 
-  if (isTTJets_LO_MET && nano.LHE_HTIncoming()>600 && !isFastSim) 
+  if (isTTJets_LO_MET && nano.LHE_HTIncoming()>600.f && !isFastSim) 
       pico.out_stitch_htmet() = pico.out_stitch_ht() = false;
 
   if ((isTTJets_LO_Incl || isTTJets_LO_MET || isTTJets_LO_HT) && !isFastSim) {
@@ -118,11 +118,11 @@ void EventTools::WriteStitch(nano_tree &nano, pico_tree &pico){
         float ph_pt = nano.GenPart_pt().at(mc_idx);
         float ph_eta = nano.GenPart_eta().at(mc_idx);
         float ph_phi = nano.GenPart_phi().at(mc_idx);
-        if (ph_pt > 13 && fabs(ph_eta)<3.0 && (nano.GenPart_statusFlags().at(mc_idx) & 0x1) == 1) {
+        if (ph_pt > 13.f && fabs(ph_eta)<3.0.f && (nano.GenPart_statusFlags().at(mc_idx) & 0x1) == 1) {
           //check if another genparticle nearby
           bool deltar_fail = false;
           for (unsigned int mc_idx_2 = 0; mc_idx_2 < nano.GenPart_pdgId().size(); mc_idx_2++) {
-            if (nano.GenPart_pt().at(mc_idx_2)>5 && dR(ph_eta,nano.GenPart_eta().at(mc_idx_2),ph_phi,nano.GenPart_phi().at(mc_idx_2))<0.2) {
+            if (nano.GenPart_pt().at(mc_idx_2)>5.f && dR(ph_eta,nano.GenPart_eta().at(mc_idx_2),ph_phi,nano.GenPart_phi().at(mc_idx_2))<0.2f) {
               deltar_fail = true;
               break;
             }
@@ -203,7 +203,7 @@ void EventTools::WriteStitch(nano_tree &nano, pico_tree &pico){
             
 
             //isPrompt and fromHardProcess already applied
-            if ( (compPart.Pt() > 5.0) && (genPhoton.DeltaR(compPart) < isocone) && (mc_idx != mc_idx_2) && (mc_statusFlags2[8]) && (nano.GenPart_pdgId().at(mc_idx_2) != 22 )  ) {
+            if ( (compPart.Pt() > 5.0f) && (genPhoton.DeltaR(compPart) < isocone) && (mc_idx != mc_idx_2) && (mc_statusFlags2[8]) && (nano.GenPart_pdgId().at(mc_idx_2) != 22 )  ) {
               found_other_particles = true;
               //Basically saying that a photon is not isolated so this is not SM Zgamma sample!
             }
@@ -233,7 +233,7 @@ void EventTools::WriteStitch(nano_tree &nano, pico_tree &pico){
             
 
             //isPrompt and fromHardProcess already applied
-            if ( (compPart.Pt() > 5.0) && (genPhoton.DeltaR(compPart) < isocone_old) && (mc_idx != mc_idx_2) && (mc_statusFlags2[8]) && (nano.GenPart_pdgId().at(mc_idx_2) != 22 )  ) {
+            if ( (compPart.Pt() > 5.0f) && (genPhoton.DeltaR(compPart) < isocone_old) && (mc_idx != mc_idx_2) && (mc_statusFlags2[8]) && (nano.GenPart_pdgId().at(mc_idx_2) != 22 )  ) {
               found_other_particles = true;
               //Basically saying that a photon is not isolated so this is not SM Zgamma sample!
             }
@@ -252,7 +252,7 @@ void EventTools::WriteStitch(nano_tree &nano, pico_tree &pico){
              compPart.SetPtEtaPhi(pico.out_photon_pt().at(reco_idx), 
                                   pico.out_photon_eta().at(reco_idx), 
                                   pico.out_photon_phi().at(reco_idx));
-            if(genPhoton.DeltaR(compPart) < 0.1){
+            if(genPhoton.DeltaR(compPart) < 0.1f){
               pico.out_old_stitch_dy() = false;
             }
           }
@@ -284,10 +284,10 @@ void EventTools::WriteStitch(nano_tree &nano, pico_tree &pico){
   }
   //Note: removed overlap removal for WW and WWG since WWG sample may have bug
 
-  if(isDYJets_LO  && nano.LHE_HT()>70) 
+  if(isDYJets_LO  && nano.LHE_HT()>70f) 
     pico.out_stitch_htmet() = pico.out_stitch_ht() = pico.out_stitch() = false;
   
-  if(isWJets_LO  && nano.LHE_HT()>70) 
+  if(isWJets_LO  && nano.LHE_HT()>70f) 
     pico.out_stitch_htmet() = pico.out_stitch_ht() = pico.out_stitch() = false;
   return;
 }
@@ -308,10 +308,10 @@ void EventTools::WriteDataQualityFilters(nano_tree& nano, pico_tree& pico, vecto
     // Fastsim: veto if certain central jets have no matching GenJet as per SUSY recommendation:
     // https://twiki.cern.ch/twiki/bin/view/CMS/SUSRecommendations18#Cleaning_up_of_fastsim_jets_from
     for(int ijet(0); ijet<nano.nJet(); ++ijet){
-      if(Jet_pt[ijet] > 20 && fabs(nano.Jet_eta()[ijet])<=2.5 && nano.Jet_chHEF()[ijet] < 0.1) {
+      if(Jet_pt[ijet] > 20f && fabs(nano.Jet_eta()[ijet])<=2.5f && nano.Jet_chHEF()[ijet] < 0.1f) {
         bool found_match = false;
         for(int igenjet(0); igenjet<nano.nGenJet(); ++igenjet){
-          if (dR(nano.Jet_eta()[ijet], nano.GenJet_eta()[igenjet], nano.Jet_phi()[ijet], nano.GenJet_phi()[igenjet])<=0.3) {
+          if (dR(nano.Jet_eta()[ijet], nano.GenJet_eta()[igenjet], nano.Jet_phi()[ijet], nano.GenJet_phi()[igenjet])<=0.3f) {
             found_match = true;
             break;
           }
@@ -334,16 +334,16 @@ void EventTools::WriteDataQualityFilters(nano_tree& nano, pico_tree& pico, vecto
   for (auto &idx: sig_jet_nano_idx){
     // if (abs(nano.Jet_eta()[idx])>2.4) continue; -> already enforced in signal jet selection
     // if is overlapping with lepton -> already enforced in signal jet selection
-    if (Jet_pt[idx]<=200.) continue;
-    if (nano.Jet_muEF()[idx]<=0.5) continue;
-    if (DeltaPhi(nano.Jet_phi()[idx],MET_phi)<(TMath::Pi()-0.4)) continue;
+    if (Jet_pt[idx]<=200.f) continue;
+    if (nano.Jet_muEF()[idx]<=0.5f) continue;
+    if (DeltaPhi(nano.Jet_phi()[idx],MET_phi)<(TMath::Pi()-0.4f)) continue;
     pico.out_pass_muon_jet() = false;
     break;
   }
 
   pico.out_pass_low_neutral_jet() = true;
   for(int ijet(0); ijet<nano.nJet();){  
-    if (nano.Jet_neEmEF()[ijet] <0.03 && DeltaPhi(nano.Jet_phi()[ijet], pico.out_met_phi())>(TMath::Pi()-0.4))
+    if (nano.Jet_neEmEF()[ijet] <0.03f && DeltaPhi(nano.Jet_phi()[ijet], pico.out_met_phi())>(TMath::Pi()-0.4f))
       pico.out_pass_low_neutral_jet() = false;
     break; //only apply to leading jet
   }
@@ -351,7 +351,7 @@ void EventTools::WriteDataQualityFilters(nano_tree& nano, pico_tree& pico, vecto
   pico.out_pass_htratio_dphi_tight() = true;
   float htratio = pico.out_ht5()/pico.out_ht();
   for(int ijet(0); ijet<nano.nJet();){  
-    if (htratio >= 1.2 && DeltaPhi(nano.Jet_phi()[ijet], pico.out_met_phi()) < (5.3*htratio - 4.78)) 
+    if (htratio >= 1.2f && DeltaPhi(nano.Jet_phi()[ijet], pico.out_met_phi()) < (5.3f*htratio - 4.78f)) 
       pico.out_pass_htratio_dphi_tight() = false;
     break; //only apply to leading jet
   }
@@ -365,9 +365,9 @@ void EventTools::WriteDataQualityFilters(nano_tree& nano, pico_tree& pico, vecto
       if (counter >= 2) break;
       float jet_pt = nano.Jet_pt()[ijet];
       if (isFastsim) jet_pt = nano.Jet_pt_nom()[ijet];
-      if (jet_pt>30 && fabs(nano.Jet_eta()[ijet])>2.4 && fabs(nano.Jet_eta()[ijet])<5.0) {
+      if (jet_pt>30 && fabs(nano.Jet_eta()[ijet])>2.4f && fabs(nano.Jet_eta()[ijet])<5.0f) {
         dphi = DeltaPhi(nano.Jet_phi()[ijet], pico.out_met_phi());
-        if (nano.Jet_pt()[ijet]>250 && (dphi > 2.6 || dphi < 0.1)) goodjet[counter] = false;
+        if (nano.Jet_pt()[ijet]>250f && (dphi > 2.6f || dphi < 0.1f)) goodjet[counter] = false;
         ++counter;
       }
     }

--- a/src/event_weighter.cpp
+++ b/src/event_weighter.cpp
@@ -137,7 +137,7 @@ void EventWeighter::ElectronSF(pico_tree &pico){
   for (unsigned imc = 0; imc < pico.out_mc_id().size(); imc++) {
     if (abs(pico.out_mc_id().at(imc))==11 && ((pico.out_mc_statusflag().at(imc) & 0x2000)!=0)) {
       //is electron and last copy
-      if ((pico.out_mc_pt().at(imc)<10) || (fabs(pico.out_mc_eta().at(imc))>2.5)) continue;
+      if ((pico.out_mc_pt().at(imc)<10f) || (fabs(pico.out_mc_eta().at(imc))>2.5f)) continue;
       bool pass_id = false;
       float reco_pt = -999;
       float reco_eta = -999;
@@ -146,7 +146,7 @@ void EventWeighter::ElectronSF(pico_tree &pico){
         if (pico.out_el_sig().at(iel)) {
           float dr = dR(pico.out_mc_eta().at(imc),pico.out_el_eta().at(iel),
                         pico.out_mc_phi().at(imc),pico.out_el_phi().at(iel));
-          if (dr < 0.2 && dr < min_dr) {
+          if (dr < 0.2f && dr < min_dr) {
             reco_pt = pico.out_el_pt().at(iel);
             reco_eta = pico.out_el_eta().at(iel);
             min_dr = dr;
@@ -166,10 +166,10 @@ void EventWeighter::ElectronSF(pico_tree &pico){
       float data_eff_dn = data_eff-data_unc;
       float mc_eff_up = mc_eff+mc_unc;
       float mc_eff_dn = mc_eff-mc_unc;
-      if (data_eff_up > 1.0) data_eff_up = 1.0;
-      if (data_eff_dn < 0.0) data_eff_dn = 0.0;
-      if (mc_eff_up > 1.0) mc_eff_up = 1.0;
-      if (mc_eff_dn < 0.0) mc_eff_dn = 0.0;
+      if (data_eff_up > 1.0f) data_eff_up = 1.0;
+      if (data_eff_dn < 0.0f) data_eff_dn = 0.0;
+      if (mc_eff_up > 1.0f) mc_eff_up = 1.0;
+      if (mc_eff_dn < 0.0f) mc_eff_dn = 0.0;
       //for variations consider "worst case": data overestimated and mc 
       //underestimated or vice-versa
       float sf = data_eff/mc_eff;
@@ -220,17 +220,17 @@ void EventWeighter::PhotonCSEVSF(pico_tree &pico, float &w_photon_csev, std::vec
                      (pico.out_photon_isScEtaEE().at(iph) && mva>-0.58));
     float drmin = pico.out_photon_drmin().at(iph);
     bool eveto = pico.out_photon_elveto().at(iph);
-    if (pt < 15 || !pass_mva || drmin < 0.4) continue;
+    if (pt < 15f || !pass_mva || drmin < 0.4f) continue;
     if (pico.out_photon_pflavor().at(iph) != 1) continue;
     //find category
     if (pico.out_photon_isScEtaEB().at(iph)) {
-      if (fabs(pico.out_photon_r9().at(iph)) > 0.94) {
+      if (fabs(pico.out_photon_r9().at(iph)) > 0.94f) {
         category = "EBHighR9";
       } else {
         category = "EBLowR9";
       }
     } else {
-      if (fabs(pico.out_photon_r9().at(iph)) > 0.94) {
+      if (fabs(pico.out_photon_r9().at(iph)) > 0.94f) {
         category = "EEHighR9";
       } else {
         category = "EELowR9";
@@ -280,7 +280,7 @@ void EventWeighter::MuonSF(pico_tree &pico){
   for (unsigned imc = 0; imc < pico.out_mc_id().size(); imc++) {
     if (abs(pico.out_mc_id().at(imc))==13 && ((pico.out_mc_statusflag().at(imc) & 0x2000)!=0)) {
       //is muon and last copy
-      if (pico.out_mc_pt().at(imc)<5 || fabs(pico.out_mc_eta().at(imc))>2.4) continue;
+      if (pico.out_mc_pt().at(imc)<5f || fabs(pico.out_mc_eta().at(imc))>2.4f) continue;
       bool pass_id = false;
       float reco_pt = -999;
       float reco_eta = -999;
@@ -289,7 +289,7 @@ void EventWeighter::MuonSF(pico_tree &pico){
         if (pico.out_mu_sig().at(imu)) {
           float dr = dR(pico.out_mc_eta().at(imc),pico.out_mu_eta().at(imu),
                         pico.out_mc_phi().at(imc),pico.out_mu_phi().at(imu));
-          if (dr < 0.1 && dr < min_dr) {
+          if (dr < 0.1f && dr < min_dr) {
             reco_pt = pico.out_mu_pt().at(imu);
             reco_eta = pico.out_mu_eta().at(imu);
             min_dr = dr;
@@ -304,7 +304,7 @@ void EventWeighter::MuonSF(pico_tree &pico){
       float sf = 1.0;
       float sf_up = 1.0;
       float sf_dn = 1.0;
-      if (reco_pt < 15) {
+      if (reco_pt < 15f) {
         float reco_sf = map_muon_lowpt_reco_->evaluate({"sf", std::abs(reco_eta), reco_pt});
         float reco_sf_unc = map_muon_lowpt_reco_->evaluate({"unc", std::abs(reco_eta), reco_pt});
         float id_sf = map_muon_lowpt_id_->evaluate({"sf", std::abs(reco_eta), reco_pt});
@@ -314,7 +314,7 @@ void EventWeighter::MuonSF(pico_tree &pico){
         sf_dn = (reco_sf-reco_sf_unc)*(id_sf-id_sf_unc);
         if (sf_dn < 0) sf_dn = 0;
       }
-      else if (reco_pt < 200) {
+      else if (reco_pt < 200f) {
         float id_sf = map_muon_looseid_->evaluate({key_ + "_UL", std::abs(reco_eta), reco_pt, "sf"});
         float id_sf_up = map_muon_looseid_->evaluate({key_ + "_UL", std::abs(reco_eta), reco_pt, "systup"});
         float id_sf_dn = map_muon_looseid_->evaluate({key_ + "_UL", std::abs(reco_eta), reco_pt, "systdown"});
@@ -340,8 +340,8 @@ void EventWeighter::MuonSF(pico_tree &pico){
       float mc_syst = map_muon_mceff_->evaluate({"systmc", std::abs(reco_eta), reco_pt});
       float mc_eff_up = mc_eff+mc_syst;
       float mc_eff_dn = mc_eff-mc_syst;
-      if (mc_eff_up > 1.0) mc_eff_up = 1.0;
-      if (mc_eff_dn < 0.0) mc_eff_dn = 0.0;
+      if (mc_eff_up > 1.0f) mc_eff_up = 1.0;
+      if (mc_eff_dn < 0.0f) mc_eff_dn = 0.0;
       float data_eff = sf*mc_eff;
       float data_eff_up = sf_up*mc_eff;
       float data_eff_dn = sf_dn*mc_eff;

--- a/src/hig_trig_eff.cpp
+++ b/src/hig_trig_eff.cpp
@@ -31,7 +31,7 @@ namespace hig_trig_eff{
   float eff(pico_tree &pico){
       float errup(0), errdown(0); // Not used, but for reference
       errup+=errdown;
-      float eff = 1., met = pico.met(), ht = pico.ht();
+      float eff = 1., met = pico.met(), ht = pico.ht(); //Note that these are floats being compared to literals (default double. . .)
       if(ht>   0 && ht<= 200 && met> 150 && met<= 155) {eff = 0.532; errup = 0.013; errdown = 0.013;}
       else if(ht> 200 && ht<= 600 && met> 150 && met<= 155) {eff = 0.612; errup = 0.005; errdown = 0.005;}
       else if(ht> 600 && ht<= 800 && met> 150 && met<= 155) {eff = 0.589; errup = 0.023; errdown = 0.024;}

--- a/src/isr_tools.cpp
+++ b/src/isr_tools.cpp
@@ -112,7 +112,7 @@ void ISRTools::WriteISRJetMultiplicity(nano_tree &nano, pico_tree &pico) {
       for (size_t idau(0); idau < child_map[imc].size(); idau++) {
         float dr_ = dR(pico.out_jet_eta()[ijet], nano.GenPart_eta()[child_map[imc][idau]], 
                       pico.out_jet_phi()[ijet], nano.GenPart_phi()[child_map[imc][idau]]);
-        if(dr_<0.3){
+        if(dr_<0.3f){
           if (verbose) cout<<"Jet: ("<<pico.out_jet_pt()[ijet]<<", "<<pico.out_jet_eta()[ijet]<<", "
                            <<pico.out_jet_phi()[ijet]<<"), MC: ("<<nano.GenPart_pt()[child_map[imc][idau]]
                            <<", "<<nano.GenPart_eta()[child_map[imc][idau]]<<", "

--- a/src/jetmet_producer.cpp
+++ b/src/jetmet_producer.cpp
@@ -133,7 +133,7 @@ void JetMetProducer::GetJetUncertainties(nano_tree &nano, pico_tree &pico,
       float jet_raw_pt = jet_type_pt[ijet]/jec;
       float jet_raw_pt_nomu = jet_raw_pt*(1.0-jet_type_muonfactor[ijet]);
       float jet_l1l2l3_pt_nomu = jet_raw_pt_nomu*jec;
-      if (jet_type == 1 && jet_l1l2l3_pt_nomu < 15) continue;
+      if (jet_type == 1 && jet_l1l2l3_pt_nomu < 15f) continue;
 
       //calculate JER (smearing) factors
       //https://twiki.cern.ch/twiki/bin/view/CMS/JetResolution#Smearing_procedures
@@ -148,7 +148,7 @@ void JetMetProducer::GetJetUncertainties(nano_tree &nano, pico_tree &pico,
       for (int igen(0); igen<nano.nGenJet(); ++igen) {
         float dr = dR(jet_type_eta[ijet], nano.GenJet_eta()[igen], jet_type_phi[ijet], nano.GenJet_phi()[ijet]);
         float dpt = jet_type_pt[ijet]-nano.GenJet_pt()[igen];
-        if (dr < 0.2 && fabs(dpt) < 3.0*sigmajer*jet_type_pt[ijet]) {
+        if (dr < 0.2f && fabs(dpt) < 3.0f*sigmajer*jet_type_pt[ijet]) {
           found_genjet = true;
           indiv_jer_nm = (1.0+(sjer_nom-1.0)*dpt/jet_type_pt[ijet]);
           indiv_jer_up = (1.0+(sjer_up-1.0)*dpt/jet_type_pt[ijet]);
@@ -187,7 +187,7 @@ void JetMetProducer::GetJetUncertainties(nano_tree &nano, pico_tree &pico,
       float jet_sinphi = sin(jet_type_phi[ijet]);
       //starting from T1 corrected MET in contrast with NanoAOD-tools
       //i.e. L2L3-L1 already done, just need to worry about variations
-      if (jet_l1l2l3_pt_nomu > 15 && fabs(jet_type_eta[ijet])<5.2 && emef < 0.9) {
+      if (jet_l1l2l3_pt_nomu > 15f && fabs(jet_type_eta[ijet])<5.2f && emef < 0.9f) {
         met_x_nom -= jet_cosphi*(jet_type_pt[ijet]*indiv_jer_nm-jet_type_pt[ijet]);
         met_y_nom -= jet_sinphi*(jet_type_pt[ijet]*indiv_jer_nm-jet_type_pt[ijet]);
         met_x_jerup -= jet_cosphi*(jet_type_pt[ijet]*indiv_jer_up-jet_type_pt[ijet]);
@@ -243,7 +243,7 @@ void JetMetProducer::WriteMet(nano_tree &nano, pico_tree &pico) {
   for (int iel = 0; iel < pico.out_nel(); iel++) {
     if (pico.out_el_sig()[iel]) {
       float unc_factor = 0.006; //EB
-      if (fabs(pico.out_el_eta()[iel])>1.5051) unc_factor = 0.015; //EE
+      if (fabs(pico.out_el_eta()[iel])>1.5051f) unc_factor = 0.015; //EE
       met_x_leptonphotonup += 
           unc_factor*cos(pico.out_el_phi()[iel])*pico.out_el_pt()[iel];
       met_y_leptonphotonup += 
@@ -257,7 +257,7 @@ void JetMetProducer::WriteMet(nano_tree &nano, pico_tree &pico) {
   for (int iph = 0; iph < pico.out_nphoton(); iph++) {
     if (pico.out_photon_sig()[iph]) {
       float unc_factor = 0.006; //EB
-      if (fabs(pico.out_photon_eta()[iph])>1.5051) unc_factor = 0.015; //EE
+      if (fabs(pico.out_photon_eta()[iph])>1.5051f) unc_factor = 0.015; //EE
       met_x_leptonphotonup += 
           unc_factor*cos(pico.out_photon_phi()[iph])*pico.out_photon_pt()[iph];
       met_y_leptonphotonup += 
@@ -403,16 +403,16 @@ vector<int> JetMetProducer::WriteJetMet(nano_tree &nano, pico_tree &pico,
 
     float veto = 0; 
     float vetoEE = 0;
-    double phicorr;
-    if(nano.Jet_phi().at(ijet)>3.1415926){ //a dumb addition because sometimes jet phi is slightly larger than pi
+    float phicorr;
+    if(nano.Jet_phi().at(ijet)>3.1415926f){ //a dumb addition because sometimes jet phi is slightly larger than pi
       phicorr = 3.1415926;
-    } else if (nano.Jet_phi().at(ijet)<-3.1415926){
+    } else if (nano.Jet_phi().at(ijet)<-3.1415926f){
       phicorr = -3.1415926;
     } else {
       phicorr = nano.Jet_phi().at(ijet);
     }
 
-    if (fabs(nano.Jet_eta()[ijet])<5.191) {
+    if (fabs(nano.Jet_eta()[ijet])<5.191f) {
       if (year==2022 && is2022preEE==true){
         map_jetveto_ = cs_jetveto_->at("Winter22Run3_RunCD_V1");
         veto = map_jetveto_->evaluate({"jetvetomap", nano.Jet_eta().at(ijet),phicorr});
@@ -445,7 +445,7 @@ vector<int> JetMetProducer::WriteJetMet(nano_tree &nano, pico_tree &pico,
                           nano.Jet_phi()[ijet], nano.Jet_mass_jerUp()[ijet]);
           sys_higvars[0].jet_lv.push_back(lv);
         }
-        if (fabs(nano.Jet_eta()[ijet]) < 2.4)
+        if (fabs(nano.Jet_eta()[ijet]) < 2.4f)
           sys_jet_met_dphi.at(0).push_back(DeltaPhi(nano.Jet_phi()[ijet], pico.out_sys_met_phi()[0]));
       }
       if (nano.Jet_pt_jerDown()[ijet] > min_jet_pt) {
@@ -477,7 +477,7 @@ vector<int> JetMetProducer::WriteJetMet(nano_tree &nano, pico_tree &pico,
                           nano.Jet_phi()[ijet], nano.Jet_mass_jesTotalUp()[ijet]);
           sys_higvars[2].jet_lv.push_back(lv);
         }
-        if (fabs(nano.Jet_eta()[ijet]) < 2.4)
+        if (fabs(nano.Jet_eta()[ijet]) < 2.4f)
           sys_jet_met_dphi.at(2).push_back(DeltaPhi(nano.Jet_phi()[ijet], pico.out_sys_met_phi()[2]));
       }
       if (nano.Jet_pt_jesTotalDown()[ijet] > min_jet_pt) {
@@ -493,7 +493,7 @@ vector<int> JetMetProducer::WriteJetMet(nano_tree &nano, pico_tree &pico,
                           nano.Jet_phi()[ijet], nano.Jet_mass_jesTotalDown()[ijet]);
           sys_higvars[3].jet_lv.push_back(lv);
         }
-        if (fabs(nano.Jet_eta()[ijet]) < 2.4)
+        if (fabs(nano.Jet_eta()[ijet]) < 2.4f)
           sys_jet_met_dphi.at(3).push_back(DeltaPhi(nano.Jet_phi()[ijet], pico.out_sys_met_phi()[3]));
       }
     }
@@ -710,7 +710,7 @@ void JetMetProducer::WriteFatJets(nano_tree &nano, pico_tree &pico){
     pico.out_fjet_subjet_idx2().push_back(FatJet_subJetIdx2[ifjet]);
 
     for(unsigned ijet(0); ijet<pico.out_jet_pt().size(); ++ijet){
-      if (dR(pico.out_jet_eta()[ijet], nano.FatJet_eta()[ifjet], pico.out_jet_phi()[ijet], nano.FatJet_phi()[ifjet])<0.8)
+      if (dR(pico.out_jet_eta()[ijet], nano.FatJet_eta()[ifjet], pico.out_jet_phi()[ijet], nano.FatJet_phi()[ifjet])<0.8f)
         pico.out_jet_fjet_idx()[ijet] = ifjet;
     }
 
@@ -742,7 +742,7 @@ void JetMetProducer::WriteSubJets(nano_tree &nano, pico_tree &pico){
       float idr = dR(pico.out_jet_eta()[ijet], nano.SubJet_eta()[isubj], pico.out_jet_phi()[ijet], nano.SubJet_phi()[isubj]);
       if (idr<mindr){
         mindr = idr;
-        if (mindr<0.4 && matched_ak4_jets.find(ijet)==matched_ak4_jets.end()) {
+        if (mindr<0.4f && matched_ak4_jets.find(ijet)==matched_ak4_jets.end()) {
           closest_jet = ijet;
           matched_ak4_jets.insert(ijet);
           break; 

--- a/src/make_zgfeats.cxx
+++ b/src/make_zgfeats.cxx
@@ -108,7 +108,7 @@ int main(int argc, char *argv[]){
     // Find best Z candidate and save attributes of Zcand and leptons
     //--------------------------------------------------------------
     if (debug) cout<<"INFO:: Filling Z candidate features."<<endl;
-    double mindm(1000);
+    double mindm(100000);
     int biz(-1);
     for(int iz(0); iz < pico.nll(); iz++)
       if(abs(pico.ll_m()[iz] - 91.1876) < mindm)

--- a/src/mu_producer.cpp
+++ b/src/mu_producer.cpp
@@ -25,11 +25,11 @@ bool MuonProducer::IsSignal(nano_tree &nano, int nano_idx, bool isZgamma) {
   if(isZgamma) { // For Zgamma productions
     if (pt <= ZgMuonPtCut) return false;
     if (fabs(eta) > MuonEtaCut) return false;
-    if (fabs(nano.Muon_dz()[nano_idx])>1.0)  return false;
-    if (fabs(nano.Muon_dxy()[nano_idx])>0.5) return false; 
-    if ((nano.Muon_looseId()[nano_idx] || (pt > 200 && nano.Muon_highPtId()[nano_idx])) && 
+    if (fabs(nano.Muon_dz()[nano_idx])>dzCut)  return false;
+    if (fabs(nano.Muon_dxy()[nano_idx])>dxyCut) return false; 
+    if ((nano.Muon_looseId()[nano_idx] || (pt > MuonHighPt && nano.Muon_highPtId()[nano_idx])) && 
          nano.Muon_pfRelIso03_all()[nano_idx] < MuonRelIsoCut &&
-         nano.Muon_sip3d()[nano_idx] < 4)
+         nano.Muon_sip3d()[nano_idx] < MuonSip3dCut)
       return true;
     return false;
   }
@@ -39,7 +39,7 @@ bool MuonProducer::IsSignal(nano_tree &nano, int nano_idx, bool isZgamma) {
     if (fabs(eta) > MuonEtaCut) return false;
     if (pt > SignalMuonPtCut &&
       nano.Muon_miniPFRelIso_all()[nano_idx] < MuonMiniIsoCut &&
-      fabs(nano.Muon_dz()[nano_idx])<=0.5 &&
+      fabs(nano.Muon_dz()[nano_idx])<=0.5 && //Maybe compare with floats here. . .
       fabs(nano.Muon_dxy()[nano_idx])<=0.2)
       return true;
     return false;
@@ -82,8 +82,8 @@ vector<int> MuonProducer::WriteMuons(nano_tree &nano, pico_tree &pico, vector<in
     if(isZgamma) { // For Zgamma productions
       if (pt <= ZgMuonPtCut) continue;
       if (fabs(eta) > MuonEtaCut) continue;
-      if (fabs(nano.Muon_dz()[imu])>1.0)  continue;
-      if (fabs(nano.Muon_dxy()[imu])>0.5) continue; 
+      if (fabs(nano.Muon_dz()[imu])>dzCut)  continue;
+      if (fabs(nano.Muon_dxy()[imu])>dxyCut) continue; 
       isSignal = IsSignal(nano, imu, isZgamma);
       pico.out_mu_sip3d().push_back(nano.Muon_sip3d()[imu]);
       pico.out_mu_mediumid().push_back(nano.Muon_mediumId()[imu]);
@@ -132,14 +132,14 @@ vector<int> MuonProducer::WriteMuons(nano_tree &nano, pico_tree &pico, vector<in
 
     // veto muon selection
     if (nano.Muon_miniPFRelIso_all()[imu] < MuonMiniIsoCut && 
-        fabs(nano.Muon_dz()[imu])<=0.5 &&
-        fabs(nano.Muon_dxy()[imu])<=0.2) {
+        fabs(nano.Muon_dz()[imu])<=0.5f &&
+        fabs(nano.Muon_dxy()[imu])<=0.2f) {
       pico.out_nvmu()++;
       pico.out_nvlep()++;
       // save indices of matching jets
       for (int ijet(0); ijet<nano.nJet(); ijet++) {
-        if (dR(nano.Muon_eta()[imu], nano.Jet_eta()[ijet], nano.Muon_phi()[imu], nano.Jet_phi()[ijet])<0.4 &&
-          fabs(Jet_pt[ijet] - nano.Muon_pt()[imu])/nano.Muon_pt()[imu] < 1)
+        if (dR(nano.Muon_eta()[imu], nano.Jet_eta()[ijet], nano.Muon_phi()[imu], nano.Jet_phi()[ijet])<0.4f &&
+          fabs(Jet_pt[ijet] - nano.Muon_pt()[imu])/nano.Muon_pt()[imu] < 1.0f)
           jet_isvlep_nano_idx.push_back(ijet);
       }
     }
@@ -151,8 +151,8 @@ vector<int> MuonProducer::WriteMuons(nano_tree &nano, pico_tree &pico, vector<in
 
       // save indices of matching jets
       for (int ijet(0); ijet<nano.nJet(); ijet++) {
-        if (dR(nano.Muon_eta()[imu], nano.Jet_eta()[ijet], nano.Muon_phi()[imu], nano.Jet_phi()[ijet])<0.4 &&
-          fabs(Jet_pt[ijet] - nano.Muon_pt()[imu])/nano.Muon_pt()[imu] < 1)
+        if (dR(nano.Muon_eta()[imu], nano.Jet_eta()[ijet], nano.Muon_phi()[imu], nano.Jet_phi()[ijet])<0.4f &&
+          fabs(Jet_pt[ijet] - nano.Muon_pt()[imu])/nano.Muon_pt()[imu] < 1.0f)
           jet_islep_nano_idx.push_back(ijet);
       }
     }

--- a/src/mu_producer.cpp
+++ b/src/mu_producer.cpp
@@ -39,8 +39,8 @@ bool MuonProducer::IsSignal(nano_tree &nano, int nano_idx, bool isZgamma) {
     if (fabs(eta) > MuonEtaCut) return false;
     if (pt > SignalMuonPtCut &&
       nano.Muon_miniPFRelIso_all()[nano_idx] < MuonMiniIsoCut &&
-      fabs(nano.Muon_dz()[nano_idx])<=0.5 && //Maybe compare with floats here. . .
-      fabs(nano.Muon_dxy()[nano_idx])<=0.2)
+      fabs(nano.Muon_dz()[nano_idx])<=0.5f && 
+      fabs(nano.Muon_dxy()[nano_idx])<=0.2f)
       return true;
     return false;
   }

--- a/src/parameterize_efficiency.cxx
+++ b/src/parameterize_efficiency.cxx
@@ -68,7 +68,7 @@ int main(int argc, char *argv[]) {
         if(entry % (num_entries/100) == 0) 
             UpdateProgressBar(float(entry)/num_entries);
         for(int ijet = 0; ijet < nJet; ijet++) {
-            if (Jet_nElectrons[ijet] != 0 || Jet_nMuons[ijet] != 0 || Jet_pt[ijet] < 30 || abs(Jet_eta[ijet]) > 2.4) 
+            if (Jet_nElectrons[ijet] != 0 || Jet_nMuons[ijet] != 0 || Jet_pt[ijet] < 30f || abs(Jet_eta[ijet]) > 2.4f) 
               continue;
             flavor = abs(Jet_hadronFlavour[ijet]);
             pt = Jet_pt[ijet];

--- a/src/photon_producer.cpp
+++ b/src/photon_producer.cpp
@@ -231,7 +231,7 @@ vector<int> PhotonProducer::WritePhotons(nano_tree &nano, pico_tree &pico, vecto
         jet_isphoton_nano_idx.push_back(Photon_jetIdx[iph]);
       else
         for (int ijet(0); ijet<nano.nJet(); ijet++)
-          if (dR(eta, nano.Jet_eta()[ijet], phi, nano.Jet_phi()[ijet])<0.4)
+          if (dR(eta, nano.Jet_eta()[ijet], phi, nano.Jet_phi()[ijet])<0.4f)
             jet_isphoton_nano_idx.push_back(ijet);
     }
   }

--- a/src/photon_producer.cpp
+++ b/src/photon_producer.cpp
@@ -86,7 +86,7 @@ vector<int> PhotonProducer::WritePhotons(nano_tree &nano, pico_tree &pico, vecto
     }
 
     bool isSignal = (nano.Photon_mvaID_WP80()[iph] &&
-                    eVeto && minLepDR > 0.3 && 
+                    eVeto && minLepDR > 0.3f && 
                     pt > SignalPhotonPtCut &&
                     (photon_el_pico_idx[iph]==-1 || !(pico.out_el_sig()[photon_el_pico_idx[iph]])));
 

--- a/src/photon_weighter.cpp
+++ b/src/photon_weighter.cpp
@@ -103,11 +103,11 @@ void PhotonWeighter::FullSim(pico_tree &pico, float &w_photon, vector<float> &sy
 
 // Returns 1.5(EB high R9), 2.5(EB low R9), 4.5(EE high R9), 5.5(EE low R9)
 float PhotonWeighter::GetRegion(float const & eta, float const & r9) {
-  if (fabs(eta) < 1.4442) { //EB
-    if (fabs(r9) > 0.94) return 1.5;
+  if (fabs(eta) < 1.4442f) { //EB
+    if (fabs(r9) > 0.94f) return 1.5;
     else return 2.5;
-  } else if (fabs(eta) < 2.5) {
-    if (fabs(r9) > 0.94) return 4.5;
+  } else if (fabs(eta) < 2.5f) {
+    if (fabs(r9) > 0.94f) return 4.5;
     else return 5.5;
   } else return -0.5;
 }

--- a/src/prefire_weighter.cpp
+++ b/src/prefire_weighter.cpp
@@ -91,7 +91,7 @@ void PrefireWeighter::EventWeight(nano_tree &nano, float & w_prefire, std::vecto
     //note: nanoAOD-tools also checks if the photon is in the electron list, we are following TreeMaker, which does not
     for (unsigned int ph_idx = 0; ph_idx < static_cast<unsigned int>(nano.nPhoton()); ph_idx++) {
       //note: TreeMaker seems to use a lower pt cut of 2. GeV while nanoAOD-tools uses a lower cut of 20. GeV
-      if (nano.Photon_pt()[ph_idx] < 2. || fabs(nano.Photon_eta()[ph_idx]) < 2.0 || fabs(nano.Photon_eta()[ph_idx]) > 3.0) {
+      if (nano.Photon_pt()[ph_idx] < 2.f || fabs(nano.Photon_eta()[ph_idx]) < 2.0f || fabs(nano.Photon_eta()[ph_idx]) > 3.0f) {
         //insert dummy SFs for unaffected photons to make indexing easier for overlap removal
         photon_sfs.push_back(std::pair<double,double>{1.,0.});
       }
@@ -102,7 +102,7 @@ void PrefireWeighter::EventWeight(nano_tree &nano, float & w_prefire, std::vecto
 
     //get prefiring SFs for jets and photons that overlap with jets
     for (unsigned int jet_idx = 0; jet_idx < static_cast<unsigned int>(nano.nJet()); jet_idx++) {
-      if (Jet_pt[jet_idx] < 2. || fabs(nano.Jet_eta()[jet_idx]) < 2.0 || fabs(nano.Jet_eta()[jet_idx]) > 3.0) continue;
+      if (Jet_pt[jet_idx] < 2.f || fabs(nano.Jet_eta()[jet_idx]) < 2.0f || fabs(nano.Jet_eta()[jet_idx]) > 3.0f) continue;
       float pt = Jet_pt[jet_idx];
       std::pair<double,double> jet_sf{1.,0.};
       if (use_jet_empt_) {
@@ -116,8 +116,8 @@ void PrefireWeighter::EventWeight(nano_tree &nano, float & w_prefire, std::vecto
       bool overlapping_photons = false;
       //photon overlap removal
       for (unsigned int ph_idx = 0; ph_idx < static_cast<unsigned int>(nano.nPhoton()); ph_idx++) {
-        if (nano.Photon_pt()[ph_idx] < 2. || fabs(nano.Photon_eta()[ph_idx]) < 2.0 || fabs(nano.Photon_eta()[ph_idx]) > 3.0) continue;
-        if (dR(nano.Photon_eta()[ph_idx], nano.Jet_eta()[jet_idx], nano.Photon_phi()[ph_idx], nano.Jet_phi()[jet_idx])<0.4) {
+        if (nano.Photon_pt()[ph_idx] < 2.f || fabs(nano.Photon_eta()[ph_idx]) < 2.0f || fabs(nano.Photon_eta()[ph_idx]) > 3.0f) continue;
+        if (dR(nano.Photon_eta()[ph_idx], nano.Jet_eta()[jet_idx], nano.Photon_phi()[ph_idx], nano.Jet_phi()[jet_idx])<0.4f) {
           overlapping_photons = true;
           if (jet_sf.first < photon_sfs[ph_idx].first) 
             //if jet non-prefire weight is lower, replace photon SF

--- a/src/tk_producer.cpp
+++ b/src/tk_producer.cpp
@@ -68,27 +68,27 @@ bool IsoTrackProducer::IsGoodTk(pico_tree &pico, bool isNanoElectron, bool isNan
   if (pdgid!=11 && pdgid!=13 && pdgid!=211) return false; 
   
   if (pdgid==11 || pdgid==13) {
-    if (pt < 5) {
+    if (pt < 5f) {
       return false;
-    } else if (pt < 25) { // fail both relative and absolute isolation! (N.B. in this pT range, absolute is always looser...)
-      if (reliso_chg >= 0.2 && reliso_chg*pt >= 5) return false; 
+    } else if (pt < 25f) { // fail both relative and absolute isolation! (N.B. in this pT range, absolute is always looser...)
+      if (reliso_chg >= 0.2f && reliso_chg*pt >= 5f) return false; 
     } else {
-      if (reliso_chg >= 0.2) return false;
+      if (reliso_chg >= 0.2f) return false;
     }
   } else {
-    if (pt < 10) {
+    if (pt < 10f) {
       return false;
-    } else if (pt < 25) {
-      if (reliso_chg >= 0.1 && reliso_chg*pt >= 5) return false;
+    } else if (pt < 25f) {
+      if (reliso_chg >= 0.1f && reliso_chg*pt >= 5f) return false;
     } else {
-      if (reliso_chg >= 0.1) return false;
+      if (reliso_chg >= 0.1f) return false;
     }
   }
 
-  if (fabs(eta) > 2.5) return false; // not applied to all tracks in Nano
-  if (fabs(dxy)  > 0.2) return false; //applied to tracks but not leptons in Nano
-  if (fabs(dz)  > 0.1) return false; //applied to tracks but not leptons in Nano
-  if (mt > 100) return false; // we should revisit whether this is useful
+  if (fabs(eta) > 2.5f) return false; // not applied to all tracks in Nano
+  if (fabs(dxy)  > 0.2f) return false; //applied to tracks but not leptons in Nano
+  if (fabs(dz)  > 0.1f) return false; //applied to tracks but not leptons in Nano
+  if (mt > 100f) return false; // we should revisit whether this is useful
 
   pico.out_tk_pdgid().push_back(pdgid);
   pico.out_tk_pt().push_back(pt);

--- a/src/trigger_weighter.cpp
+++ b/src/trigger_weighter.cpp
@@ -126,9 +126,9 @@ std::vector<float> TriggerWeighter::GetSF(std::vector<float> electron_pt,
   float sf_dn = data_prob[2]/mc_prob[1];
 
   //deal with signal leptons with low probabilities
-  if (mc_prob[0]<0.001 || data_prob[0]<0.001) sf = 1.0;
-  if (mc_prob[1]<0.001 || data_prob[1]<0.001) sf_up = 1.0;
-  if (mc_prob[2]<0.001 || data_prob[2]<0.001) sf_dn = 1.0;
+  if (mc_prob[0]<0.001f || data_prob[0]<0.001f) sf = 1.0;
+  if (mc_prob[1]<0.001f || data_prob[1]<0.001f) sf_up = 1.0;
+  if (mc_prob[2]<0.001f || data_prob[2]<0.001f) sf_dn = 1.0;
 
   return {sf, sf_up, sf_dn};
 }
@@ -342,8 +342,8 @@ std::vector<float> TriggerWeighter::GetLeptonProbability(float lepton_pt, float 
   float uncr = (*prob_map)->evaluate({unc_name, std::abs(lepton_eta), lepton_pt});
   float up = prob + uncr;
   float down = prob - uncr;
-  if (up > 1.0) up = 1.0;
-  if (down < 0.0) down = 0.0;
+  if (up > 1.0f) up = 1.0;
+  if (down < 0.0f) down = 0.0;
   return {prob, up, down};
 }
 

--- a/src/zgamma_producer.cpp
+++ b/src/zgamma_producer.cpp
@@ -436,21 +436,21 @@ void ZGammaVarProducer::WriteZGammaVars(nano_tree &nano, pico_tree &pico, vector
   pico.out_trig_mu_pt() = false;
   if (year==2016) {
     if(pico.out_nel() > 1){
-      if(pico.out_trig_double_el() && pico.out_lep_pt().at(0)>25 && pico.out_lep_pt().at(1)>15){
+      if(pico.out_trig_double_el() && pico.out_lep_pt().at(0)>25.f && pico.out_lep_pt().at(1)>15.f){
         pico.out_trig_el_pt() = true;
       }
     } else if(pico.out_nel() > 0){
-      if(pico.out_trig_single_el() && pico.out_lep_pt().at(0)>30){
+      if(pico.out_trig_single_el() && pico.out_lep_pt().at(0)>30.f){
         pico.out_trig_el_pt() = true;
       }
     }
   
     if(pico.out_nmu() > 1){
-      if(pico.out_trig_double_mu() && pico.out_lep_pt().at(0)>20 && pico.out_lep_pt().at(1)>10){
+      if(pico.out_trig_double_mu() && pico.out_lep_pt().at(0)>20.f && pico.out_lep_pt().at(1)>10.f){
         pico.out_trig_mu_pt() = true;
       } 
     }else if(pico.out_nmu() > 0){ 
-      if(pico.out_trig_single_mu() && pico.out_lep_pt().at(0)>25){
+      if(pico.out_trig_single_mu() && pico.out_lep_pt().at(0)>25.f){
         pico.out_trig_mu_pt() = true;
       }
     }
@@ -458,21 +458,21 @@ void ZGammaVarProducer::WriteZGammaVars(nano_tree &nano, pico_tree &pico, vector
   
   if (year==2017) {
     if(pico.out_nel() > 1){
-      if(pico.out_trig_double_el() && pico.out_lep_pt().at(0)>25 && pico.out_lep_pt().at(1)>15){
+      if(pico.out_trig_double_el() && pico.out_lep_pt().at(0)>25.f && pico.out_lep_pt().at(1)>15.f){
         pico.out_trig_el_pt() = true;
       }
     } else if(pico.out_nel() > 0){
-      if(pico.out_trig_single_el() && pico.out_lep_pt().at(0)>35){
+      if(pico.out_trig_single_el() && pico.out_lep_pt().at(0)>35.f){
         pico.out_trig_el_pt() = true;
       }
     }
   
     if(pico.out_nmu() > 1){
-      if(pico.out_trig_double_mu() && pico.out_lep_pt().at(0)>20 && pico.out_lep_pt().at(1)>10){
+      if(pico.out_trig_double_mu() && pico.out_lep_pt().at(0)>20.f && pico.out_lep_pt().at(1)>10.f){
         pico.out_trig_mu_pt() = true;
       } 
     }else if(pico.out_nmu() > 0){ 
-      if(pico.out_trig_single_mu() && pico.out_lep_pt().at(0)>28){
+      if(pico.out_trig_single_mu() && pico.out_lep_pt().at(0)>28.f){
         pico.out_trig_mu_pt() = true;
       }
     }
@@ -480,21 +480,21 @@ void ZGammaVarProducer::WriteZGammaVars(nano_tree &nano, pico_tree &pico, vector
 
   if (year==2018 || year==2022 || year==2023) {
     if(pico.out_nel() > 1){
-      if(pico.out_trig_double_el() && pico.out_lep_pt().at(0)>25 && pico.out_lep_pt().at(1)>15){
+      if(pico.out_trig_double_el() && pico.out_lep_pt().at(0)>25.f && pico.out_lep_pt().at(1)>15.f){
         pico.out_trig_el_pt() = true;
       }
     } else if(pico.out_nel() > 0){
-      if(pico.out_trig_single_el() && pico.out_lep_pt().at(0)>35){
+      if(pico.out_trig_single_el() && pico.out_lep_pt().at(0)>35.f){
         pico.out_trig_el_pt() = true;
       }
     }
   
     if(pico.out_nmu() > 1){
-      if(pico.out_trig_double_mu() && pico.out_lep_pt().at(0)>20 && pico.out_lep_pt().at(1)>10){
+      if(pico.out_trig_double_mu() && pico.out_lep_pt().at(0)>20.f && pico.out_lep_pt().at(1)>10.f){
         pico.out_trig_mu_pt() = true;
       } 
     }else if(pico.out_nmu() > 0){ 
-      if(pico.out_trig_single_mu() && pico.out_lep_pt().at(0)>25){
+      if(pico.out_trig_single_mu() && pico.out_lep_pt().at(0)>25.f){
         pico.out_trig_mu_pt() = true;
       }
     }
@@ -522,11 +522,11 @@ void ZGammaVarProducer::WriteZGammaVars(nano_tree &nano, pico_tree &pico, vector
     if(pico.out_trig_mu_pt()){baseBit +=0b00001000000;}
   }
   if (pico.out_nphoton()>=1){baseBit+= 0b00000100000;}
-  if (pico.out_ll_m().at(pico.out_llphoton_ill().at(0))>=80 && pico.out_ll_m().at(pico.out_llphoton_ill().at(0))<=100){baseBit+= 0b00000010000;}
-  if(pico.out_photon_pt().at(pico.out_llphoton_iph().at(0))/pico.out_llphoton_m().at(0) >=15.0/110){baseBit+= 0b00000001000;}
-  if(pico.out_ll_m().at(pico.out_llphoton_ill().at(0))+pico.out_llphoton_m().at(0) > 185){baseBit+= 0b00000000100;}
-  if (pico.out_llphoton_m().at(0)>=100 && pico.out_llphoton_m().at(0)<=180){baseBit+= 0b00000000010;}
-  if(pico.out_llphoton_m().at(0)<=122 || pico.out_llphoton_m().at(0)>=128){baseBit+= 0b00000000001;}
+  if (pico.out_ll_m().at(pico.out_llphoton_ill().at(0))>=80.f && pico.out_ll_m().at(pico.out_llphoton_ill().at(0))<=100.f){baseBit+= 0b00000010000;}
+  if(pico.out_photon_pt().at(pico.out_llphoton_iph().at(0))/pico.out_llphoton_m().at(0) >=15.0f/110.f){baseBit+= 0b00000001000;}
+  if(pico.out_ll_m().at(pico.out_llphoton_ill().at(0))+pico.out_llphoton_m().at(0) > 185.f){baseBit+= 0b00000000100;}
+  if (pico.out_llphoton_m().at(0)>=100.f && pico.out_llphoton_m().at(0)<=180.f){baseBit+= 0b00000000010;}
+  if(pico.out_llphoton_m().at(0)<=122.f || pico.out_llphoton_m().at(0)>=128.f){baseBit+= 0b00000000001;}
 
   pico.out_zg_cutBitMap() = baseBit;
 //End Bitmap for zgamma cut flow


### PR DESCRIPTION
Searched through code for every instance of if comparison between nanoAOD single precision floats and literals (i.e. "0.2") and changed literals to be float literals ("0.2f"). This was inconsistently implemented before. 

Exceptions: Comparisons with 0, and comparisons not involving an if statement. Should still be more consistent, more changes can be made in future if needed.