### PR TITLE
fixed some long long int errors and added photon_idx_hig019014 variable.

### DIFF
--- a/src/el_producer.cpp
+++ b/src/el_producer.cpp
@@ -216,7 +216,7 @@ vector<int> ElectronProducer::WriteElectrons(nano_tree &nano, pico_tree &pico, v
       // save indices of matching jets
       for (int ijet(0); ijet<nano.nJet(); ijet++) {
         if (dR(eta, nano.Jet_eta()[ijet], phi, nano.Jet_phi()[ijet])<0.4f &&
-            fabs(Jet_pt[ijet] - nano.Electron_pt()[iel])/nano.Electron_pt()[iel] < 1f)
+            fabs(Jet_pt[ijet] - nano.Electron_pt()[iel])/nano.Electron_pt()[iel] < 1.f)
           jet_isvlep_nano_idx.push_back(ijet);
       }
     }

--- a/src/event_tools.cpp
+++ b/src/event_tools.cpp
@@ -118,7 +118,7 @@ void EventTools::WriteStitch(nano_tree &nano, pico_tree &pico){
         float ph_pt = nano.GenPart_pt().at(mc_idx);
         float ph_eta = nano.GenPart_eta().at(mc_idx);
         float ph_phi = nano.GenPart_phi().at(mc_idx);
-        if (ph_pt > 13.f && fabs(ph_eta)<3.0.f && (nano.GenPart_statusFlags().at(mc_idx) & 0x1) == 1) {
+        if (ph_pt > 13.f && fabs(ph_eta)<3.0f && (nano.GenPart_statusFlags().at(mc_idx) & 0x1) == 1) {
           //check if another genparticle nearby
           bool deltar_fail = false;
           for (unsigned int mc_idx_2 = 0; mc_idx_2 < nano.GenPart_pdgId().size(); mc_idx_2++) {
@@ -284,10 +284,10 @@ void EventTools::WriteStitch(nano_tree &nano, pico_tree &pico){
   }
   //Note: removed overlap removal for WW and WWG since WWG sample may have bug
 
-  if(isDYJets_LO  && nano.LHE_HT()>70f) 
+  if(isDYJets_LO  && nano.LHE_HT()>70.f) 
     pico.out_stitch_htmet() = pico.out_stitch_ht() = pico.out_stitch() = false;
   
-  if(isWJets_LO  && nano.LHE_HT()>70f) 
+  if(isWJets_LO  && nano.LHE_HT()>70.f) 
     pico.out_stitch_htmet() = pico.out_stitch_ht() = pico.out_stitch() = false;
   return;
 }
@@ -308,7 +308,7 @@ void EventTools::WriteDataQualityFilters(nano_tree& nano, pico_tree& pico, vecto
     // Fastsim: veto if certain central jets have no matching GenJet as per SUSY recommendation:
     // https://twiki.cern.ch/twiki/bin/view/CMS/SUSRecommendations18#Cleaning_up_of_fastsim_jets_from
     for(int ijet(0); ijet<nano.nJet(); ++ijet){
-      if(Jet_pt[ijet] > 20f && fabs(nano.Jet_eta()[ijet])<=2.5f && nano.Jet_chHEF()[ijet] < 0.1f) {
+      if(Jet_pt[ijet] > 20.f && fabs(nano.Jet_eta()[ijet])<=2.5f && nano.Jet_chHEF()[ijet] < 0.1f) {
         bool found_match = false;
         for(int igenjet(0); igenjet<nano.nGenJet(); ++igenjet){
           if (dR(nano.Jet_eta()[ijet], nano.GenJet_eta()[igenjet], nano.Jet_phi()[ijet], nano.GenJet_phi()[igenjet])<=0.3f) {
@@ -367,7 +367,7 @@ void EventTools::WriteDataQualityFilters(nano_tree& nano, pico_tree& pico, vecto
       if (isFastsim) jet_pt = nano.Jet_pt_nom()[ijet];
       if (jet_pt>30 && fabs(nano.Jet_eta()[ijet])>2.4f && fabs(nano.Jet_eta()[ijet])<5.0f) {
         dphi = DeltaPhi(nano.Jet_phi()[ijet], pico.out_met_phi());
-        if (nano.Jet_pt()[ijet]>250f && (dphi > 2.6f || dphi < 0.1f)) goodjet[counter] = false;
+        if (nano.Jet_pt()[ijet]>250.f && (dphi > 2.6f || dphi < 0.1f)) goodjet[counter] = false;
         ++counter;
       }
     }

--- a/src/event_weighter.cpp
+++ b/src/event_weighter.cpp
@@ -137,7 +137,7 @@ void EventWeighter::ElectronSF(pico_tree &pico){
   for (unsigned imc = 0; imc < pico.out_mc_id().size(); imc++) {
     if (abs(pico.out_mc_id().at(imc))==11 && ((pico.out_mc_statusflag().at(imc) & 0x2000)!=0)) {
       //is electron and last copy
-      if ((pico.out_mc_pt().at(imc)<10f) || (fabs(pico.out_mc_eta().at(imc))>2.5f)) continue;
+      if ((pico.out_mc_pt().at(imc)<10.f) || (fabs(pico.out_mc_eta().at(imc))>2.5f)) continue;
       bool pass_id = false;
       float reco_pt = -999;
       float reco_eta = -999;
@@ -220,7 +220,7 @@ void EventWeighter::PhotonCSEVSF(pico_tree &pico, float &w_photon_csev, std::vec
                      (pico.out_photon_isScEtaEE().at(iph) && mva>-0.58));
     float drmin = pico.out_photon_drmin().at(iph);
     bool eveto = pico.out_photon_elveto().at(iph);
-    if (pt < 15f || !pass_mva || drmin < 0.4f) continue;
+    if (pt < 15.f || !pass_mva || drmin < 0.4f) continue;
     if (pico.out_photon_pflavor().at(iph) != 1) continue;
     //find category
     if (pico.out_photon_isScEtaEB().at(iph)) {
@@ -280,7 +280,7 @@ void EventWeighter::MuonSF(pico_tree &pico){
   for (unsigned imc = 0; imc < pico.out_mc_id().size(); imc++) {
     if (abs(pico.out_mc_id().at(imc))==13 && ((pico.out_mc_statusflag().at(imc) & 0x2000)!=0)) {
       //is muon and last copy
-      if (pico.out_mc_pt().at(imc)<5f || fabs(pico.out_mc_eta().at(imc))>2.4f) continue;
+      if (pico.out_mc_pt().at(imc)<5.f || fabs(pico.out_mc_eta().at(imc))>2.4f) continue;
       bool pass_id = false;
       float reco_pt = -999;
       float reco_eta = -999;
@@ -304,7 +304,7 @@ void EventWeighter::MuonSF(pico_tree &pico){
       float sf = 1.0;
       float sf_up = 1.0;
       float sf_dn = 1.0;
-      if (reco_pt < 15f) {
+      if (reco_pt < 15.f) {
         float reco_sf = map_muon_lowpt_reco_->evaluate({"sf", std::abs(reco_eta), reco_pt});
         float reco_sf_unc = map_muon_lowpt_reco_->evaluate({"unc", std::abs(reco_eta), reco_pt});
         float id_sf = map_muon_lowpt_id_->evaluate({"sf", std::abs(reco_eta), reco_pt});
@@ -314,7 +314,7 @@ void EventWeighter::MuonSF(pico_tree &pico){
         sf_dn = (reco_sf-reco_sf_unc)*(id_sf-id_sf_unc);
         if (sf_dn < 0) sf_dn = 0;
       }
-      else if (reco_pt < 200f) {
+      else if (reco_pt < 200.f) {
         float id_sf = map_muon_looseid_->evaluate({key_ + "_UL", std::abs(reco_eta), reco_pt, "sf"});
         float id_sf_up = map_muon_looseid_->evaluate({key_ + "_UL", std::abs(reco_eta), reco_pt, "systup"});
         float id_sf_dn = map_muon_looseid_->evaluate({key_ + "_UL", std::abs(reco_eta), reco_pt, "systdown"});

--- a/src/jetmet_producer.cpp
+++ b/src/jetmet_producer.cpp
@@ -133,7 +133,7 @@ void JetMetProducer::GetJetUncertainties(nano_tree &nano, pico_tree &pico,
       float jet_raw_pt = jet_type_pt[ijet]/jec;
       float jet_raw_pt_nomu = jet_raw_pt*(1.0-jet_type_muonfactor[ijet]);
       float jet_l1l2l3_pt_nomu = jet_raw_pt_nomu*jec;
-      if (jet_type == 1 && jet_l1l2l3_pt_nomu < 15f) continue;
+      if (jet_type == 1 && jet_l1l2l3_pt_nomu < 15.f) continue;
 
       //calculate JER (smearing) factors
       //https://twiki.cern.ch/twiki/bin/view/CMS/JetResolution#Smearing_procedures
@@ -187,7 +187,7 @@ void JetMetProducer::GetJetUncertainties(nano_tree &nano, pico_tree &pico,
       float jet_sinphi = sin(jet_type_phi[ijet]);
       //starting from T1 corrected MET in contrast with NanoAOD-tools
       //i.e. L2L3-L1 already done, just need to worry about variations
-      if (jet_l1l2l3_pt_nomu > 15f && fabs(jet_type_eta[ijet])<5.2f && emef < 0.9f) {
+      if (jet_l1l2l3_pt_nomu > 15.f && fabs(jet_type_eta[ijet])<5.2f && emef < 0.9f) {
         met_x_nom -= jet_cosphi*(jet_type_pt[ijet]*indiv_jer_nm-jet_type_pt[ijet]);
         met_y_nom -= jet_sinphi*(jet_type_pt[ijet]*indiv_jer_nm-jet_type_pt[ijet]);
         met_x_jerup -= jet_cosphi*(jet_type_pt[ijet]*indiv_jer_up-jet_type_pt[ijet]);

--- a/src/parameterize_efficiency.cxx
+++ b/src/parameterize_efficiency.cxx
@@ -68,7 +68,7 @@ int main(int argc, char *argv[]) {
         if(entry % (num_entries/100) == 0) 
             UpdateProgressBar(float(entry)/num_entries);
         for(int ijet = 0; ijet < nJet; ijet++) {
-            if (Jet_nElectrons[ijet] != 0 || Jet_nMuons[ijet] != 0 || Jet_pt[ijet] < 30f || abs(Jet_eta[ijet]) > 2.4f) 
+            if (Jet_nElectrons[ijet] != 0 || Jet_nMuons[ijet] != 0 || Jet_pt[ijet] < 30.f || abs(Jet_eta[ijet]) > (2.4)) 
               continue;
             flavor = abs(Jet_hadronFlavour[ijet]);
             pt = Jet_pt[ijet];

--- a/src/photon_producer.cpp
+++ b/src/photon_producer.cpp
@@ -92,8 +92,8 @@ vector<int> PhotonProducer::WritePhotons(nano_tree &nano, pico_tree &pico, vecto
                     eVeto && minLepDR > 0.3f && 
                     pt > SignalPhotonPtCut &&
                     (photon_el_pico_idx[iph]==-1 || !(pico.out_el_sig()[photon_el_pico_idx[iph]])));
-    bool isSignalhig019014 = (((nano.Photon_isScEtaEB()[iph] && mva > -0.4) || (nano.Photon_isScEtaEE()[iph] && mva > -0.58)) &&
-                             eVeto && minLepDR > 0.4 && pt > SignalPhotonPtCut);
+    bool isSignalhig019014 = (((nano.Photon_isScEtaEB()[iph] && mva > -0.4f) || (nano.Photon_isScEtaEE()[iph] && mva > -0.58f)) &&
+                             eVeto && minLepDR > 0.4f && pt > SignalPhotonPtCut);
 
     if(hig019014_photon_idx==-1 && isSignalhig019014){
       pico.out_photon_idx_hig019014() = iph;

--- a/src/photon_producer.cpp
+++ b/src/photon_producer.cpp
@@ -51,6 +51,9 @@ vector<int> PhotonProducer::WritePhotons(nano_tree &nano, pico_tree &pico, vecto
   // pico.out_nfsrphoton() = 0;
   vector<int> sig_photon_nano_idx;
   int nphotons(0), ndr(0), shift(0);
+  int hig019014_photon_idx = -1;
+  //Set a default value 
+  pico.out_photon_idx_hig019014() = -1;
 
   vector<int> FsrPhoton_muonIdx;
   getFsrPhoton_muonIdx(nano, nanoaod_version, FsrPhoton_muonIdx);
@@ -89,6 +92,13 @@ vector<int> PhotonProducer::WritePhotons(nano_tree &nano, pico_tree &pico, vecto
                     eVeto && minLepDR > 0.3f && 
                     pt > SignalPhotonPtCut &&
                     (photon_el_pico_idx[iph]==-1 || !(pico.out_el_sig()[photon_el_pico_idx[iph]])));
+    bool isSignalhig019014 = (((nano.Photon_isScEtaEB()[iph] && mva > -0.4) || (nano.Photon_isScEtaEE()[iph] && mva > -0.58)) &&
+                             eVeto && minLepDR > 0.4 && pt > SignalPhotonPtCut);
+
+    if(hig019014_photon_idx==-1 && isSignalhig019014){
+      pico.out_photon_idx_hig019014() = iph;
+      hig019014_photon_idx = iph;
+    }
 
     // Photons passing the object selections are placed at the front
     if(isSignal) {

--- a/src/tk_producer.cpp
+++ b/src/tk_producer.cpp
@@ -68,18 +68,18 @@ bool IsoTrackProducer::IsGoodTk(pico_tree &pico, bool isNanoElectron, bool isNan
   if (pdgid!=11 && pdgid!=13 && pdgid!=211) return false; 
   
   if (pdgid==11 || pdgid==13) {
-    if (pt < 5f) {
+    if (pt < 5.f) {
       return false;
-    } else if (pt < 25f) { // fail both relative and absolute isolation! (N.B. in this pT range, absolute is always looser...)
-      if (reliso_chg >= 0.2f && reliso_chg*pt >= 5f) return false; 
+    } else if (pt < 25.f) { // fail both relative and absolute isolation! (N.B. in this pT range, absolute is always looser...)
+      if (reliso_chg >= 0.2f && reliso_chg*pt >= 5.f) return false; 
     } else {
       if (reliso_chg >= 0.2f) return false;
     }
   } else {
-    if (pt < 10f) {
+    if (pt < 10.f) {
       return false;
-    } else if (pt < 25f) {
-      if (reliso_chg >= 0.1f && reliso_chg*pt >= 5f) return false;
+    } else if (pt < 25.f) {
+      if (reliso_chg >= 0.1f && reliso_chg*pt >= 5.f) return false;
     } else {
       if (reliso_chg >= 0.1f) return false;
     }
@@ -88,7 +88,7 @@ bool IsoTrackProducer::IsGoodTk(pico_tree &pico, bool isNanoElectron, bool isNan
   if (fabs(eta) > 2.5f) return false; // not applied to all tracks in Nano
   if (fabs(dxy)  > 0.2f) return false; //applied to tracks but not leptons in Nano
   if (fabs(dz)  > 0.1f) return false; //applied to tracks but not leptons in Nano
-  if (mt > 100f) return false; // we should revisit whether this is useful
+  if (mt > 100.f) return false; // we should revisit whether this is useful
 
   pico.out_tk_pdgid().push_back(pdgid);
   pico.out_tk_pt().push_back(pt);

--- a/txt/variables/pico
+++ b/txt/variables/pico
@@ -318,6 +318,7 @@ float ll_refit_minnll
 
 ##################   Photons   ###################
 int nphoton
+int photon_idx_hig019014
 vector<float> photon_pt
 vector<float> photon_eta
 vector<float> photon_phi


### PR DESCRIPTION
Changes:
- Fixed some errors with the use of float literals 
- Added variable that denotes which photon would be signal photon candidate by HIG-019-014 analysis

Note: photon_idx_hig019014 does not contain the removal of photon candidates via the photon_elidx variable.