### PR TITLE
Implementing changes in NanoAOD v12 & switching to mvaHZZIso for HZG electron Run 3

### DIFF
--- a/inc/hig_producer.hpp
+++ b/inc/hig_producer.hpp
@@ -20,7 +20,7 @@ public:
   ~HigVarProducer();
 
   void WriteHigVars(pico_tree& pico, bool doDeepFlav, bool isSignal,
-                    std::vector<HiggsConstructionVariables> sys_higvars);
+                    std::vector<HiggsConstructionVariables> sys_higvars, float nanoaod_version);
 
 private:
   int year;

--- a/inc/isr_tools.hpp
+++ b/inc/isr_tools.hpp
@@ -8,7 +8,7 @@
 class ISRTools{
 public:
 
-  explicit ISRTools(const std::string &name, int year);
+  explicit ISRTools(const std::string &name, int year, float nanoaod_version);
   ~ISRTools();
 
   bool IsLastCopyBeforeFSR_or_LastCopy(nano_tree &nano, int mc_index);
@@ -25,6 +25,7 @@ private:
   bool isTTJets_LO;
   bool isGluino;
   bool isTChi;
+  float nanoaod_version;
 
 };
 

--- a/inc/mc_producer.hpp
+++ b/inc/mc_producer.hpp
@@ -8,7 +8,7 @@
 class GenParticleProducer{
 public:
 
-  explicit GenParticleProducer(int year);
+  explicit GenParticleProducer(int year,float nanoaod_version);
   ~GenParticleProducer();
 
   void WriteGenParticles(nano_tree &nano, pico_tree &pico);
@@ -19,7 +19,7 @@ public:
   int GetMotherIdx(nano_tree & nano, int imc, std::map<int, int> & mc_index_to_interested_index);
 private:
   int year;
-  
+  float nanoaod_version;
 };
 
 #endif

--- a/inc/utilities.hpp
+++ b/inc/utilities.hpp
@@ -120,5 +120,12 @@ void getPhoton_jetIdx(nano_tree & nano, float nanoaod_version, std::vector<int> 
 void getPhoton_cutBased(nano_tree & nano, float nanoaod_version, std::vector<int> & Photon_cutBased);
 void getFatJet_subJetIdx1(nano_tree & nano, float nanoaod_version, std::vector<int> & FatJet_subJetIdx1);
 void getFatJet_subJetIdx2(nano_tree & nano, float nanoaod_version, std::vector<int> & FatJet_subJetIdx2);
-
+void getMuon_nTrackerLayers(nano_tree & nano, float nanoaod_version, std::vector<int> & Muon_nTrackerLayers);
+void getMuon_genPartIdx(nano_tree & nano, float nanoaod_version, std::vector<int> & Muon_genPartIdx);
+void getJet_genJetIdx(nano_tree & nano, float nanoaod_version, std::vector<int> & Jet_genJetIdx);
+void getJet_hadronFlavour(nano_tree & nano, float nanoaod_version, std::vector<int> & Jet_hadronFlavour);
+void getJet_partonFlavour(nano_tree & nano, float nanoaod_version, std::vector<int> & Jet_partonFlavour);
+void getGenPart_genPartIdxMother(nano_tree & nano, float nanoaod_version, std::vector<int> & GenPart_genPartIdxMother);
+void getGenPart_statusFlags(nano_tree & nano, float nanoaod_version, std::vector<int> & GenPart_statusFlags);
+void getGenJet_partonFlavour(nano_tree & nano, float nanoaod_version, std::vector<int> & GenJet_partonFlavour);
 #endif

--- a/src/el_producer.cpp
+++ b/src/el_producer.cpp
@@ -65,6 +65,15 @@ bool ElectronProducer::IsSignal(nano_tree &nano, int nano_idx, bool isZgamma) {
         return nano.Electron_mvaFall17V2Iso_WPL()[nano_idx];
       case 2022:
       case 2023:
+	float mvaHZZ = nano.Electron_mvaHZZIso()[nano_idx];
+	// got these values from : https://twiki.cern.ch/twiki/bin/viewauth/CMS/MultivariateElectronIdentificationRun2#HZZ_MVA_training_details_and_wor
+	//early Run 3 HZZ SF is approved applying the 2018 WP
+	return ((pt < 10. && fabs(eta) < 0.800 && mvaHZZ > 1.49603193295) ||\
+		(pt < 10. && fabs(eta) >= 0.800 && abs(eta) < 1.479 && mvaHZZ > 1.52414154008) ||\
+		(pt < 10. && fabs(eta) >= 1.479 && mvaHZZ > 1.77694249574)||\
+		(pt >= 10. && fabs(eta) < 0.800 && mvaHZZ > 0.199463934736) ||\
+		(pt >= 10. && fabs(eta) >= 0.800 && abs(eta) < 1.479 && mvaHZZ > 0.076063564084) ||\
+		(pt >= 10. && fabs(eta) >= 1.479 && mvaHZZ > -0.572118857519));
       default:
         return nano.Electron_mvaIso_WP90()[nano_idx];
     }
@@ -163,6 +172,7 @@ vector<int> ElectronProducer::WriteElectrons(nano_tree &nano, pico_tree &pico, v
         case 2022:
         case 2023:
           pico.out_el_idmva().push_back(nano.Electron_mvaIso()[iel]);
+	  pico.out_el_idmvaHZZ().push_back(nano.Electron_mvaHZZIso()[iel]);
           pico.out_el_sip3d().push_back(nano.Electron_sip3d()[iel]);
           pico.out_el_phidx().push_back(Electron_photonIdx[iel]);
           pico.out_el_id80().push_back(nano.Electron_mvaIso_WP80()[iel]);

--- a/src/el_producer.cpp
+++ b/src/el_producer.cpp
@@ -67,12 +67,13 @@ bool ElectronProducer::IsSignal(nano_tree &nano, int nano_idx, bool isZgamma) {
       case 2023:
 	// got these values from : https://twiki.cern.ch/twiki/bin/viewauth/CMS/MultivariateElectronIdentificationRun2#HZZ_MVA_training_details_and_wor
 	//early Run 3 HZZ SF is approved applying the 2018 WP
-	return ((pt < 10. && fabs(eta) < 0.800 && nano.Electron_mvaHZZIso()[nano_idx] > 1.49603193295) ||\
-		(pt < 10. && fabs(eta) >= 0.800 && fabs(eta) < 1.479 && nano.Electron_mvaHZZIso()[nano_idx] > 1.52414154008) ||\
-		(pt < 10. && fabs(eta) >= 1.479 && nano.Electron_mvaHZZIso()[nano_idx] > 1.77694249574)||\
-		(pt >= 10. && fabs(eta) < 0.800 && nano.Electron_mvaHZZIso()[nano_idx] > 0.199463934736) ||\
-		(pt >= 10. && fabs(eta) >= 0.800 && fabs(eta) < 1.479 && nano.Electron_mvaHZZIso()[nano_idx] > 0.076063564084) ||\
-		(pt >= 10. && fabs(eta) >= 1.479 && nano.Electron_mvaHZZIso()[nano_idx] > -0.572118857519));
+	// 2.0 / (1.0 + exp(-2.0 * response)) - 1)
+	return ((pt < 10. && fabs(etasc) < 0.800 && nano.Electron_mvaHZZIso()[nano_idx] > ConvertMVA(1.49603193295)) || \
+		(pt < 10. && fabs(etasc) >= 0.800 && fabs(etasc) < 1.479 && nano.Electron_mvaHZZIso()[nano_idx] > ConvertMVA(1.52414154008)) || \
+		(pt < 10. && fabs(etasc) >= 1.479 && nano.Electron_mvaHZZIso()[nano_idx] > ConvertMVA(1.77694249574))|| \
+		(pt >= 10. && fabs(etasc) < 0.800 && nano.Electron_mvaHZZIso()[nano_idx] > ConvertMVA(0.199463934736)) || \
+		(pt >= 10. && fabs(etasc) >= 0.800 && fabs(etasc) < 1.479 && nano.Electron_mvaHZZIso()[nano_idx] > ConvertMVA(0.076063564084))|| \
+		(pt >= 10. && fabs(etasc) >= 1.479 && nano.Electron_mvaHZZIso()[nano_idx] > ConvertMVA(-0.572118857519)));
       default:
         return nano.Electron_mvaIso_WP90()[nano_idx];
     }
@@ -273,6 +274,11 @@ bool ElectronProducer::idElectron_noIso(int bitmap, int level){
     if ( ((bitmap >> i*3) & 0x7) < level) pass = false;
   }
   return pass;
+}
+
+float ElectronProducer::ConvertMVA(float mva_mini) {
+  float mva_nano = 2.0 / (1.0 + exp(-2.0 * mva_mini) - 1);
+  return mva_nano;
 }
 
 bool ElectronProducer::EcalDriven(int bitmap){

--- a/src/el_producer.cpp
+++ b/src/el_producer.cpp
@@ -65,15 +65,14 @@ bool ElectronProducer::IsSignal(nano_tree &nano, int nano_idx, bool isZgamma) {
         return nano.Electron_mvaFall17V2Iso_WPL()[nano_idx];
       case 2022:
       case 2023:
-	float mvaHZZ = nano.Electron_mvaHZZIso()[nano_idx];
 	// got these values from : https://twiki.cern.ch/twiki/bin/viewauth/CMS/MultivariateElectronIdentificationRun2#HZZ_MVA_training_details_and_wor
 	//early Run 3 HZZ SF is approved applying the 2018 WP
-	return ((pt < 10. && fabs(eta) < 0.800 && mvaHZZ > 1.49603193295) ||\
-		(pt < 10. && fabs(eta) >= 0.800 && abs(eta) < 1.479 && mvaHZZ > 1.52414154008) ||\
-		(pt < 10. && fabs(eta) >= 1.479 && mvaHZZ > 1.77694249574)||\
-		(pt >= 10. && fabs(eta) < 0.800 && mvaHZZ > 0.199463934736) ||\
-		(pt >= 10. && fabs(eta) >= 0.800 && abs(eta) < 1.479 && mvaHZZ > 0.076063564084) ||\
-		(pt >= 10. && fabs(eta) >= 1.479 && mvaHZZ > -0.572118857519));
+	return ((pt < 10. && fabs(eta) < 0.800 && nano.Electron_mvaHZZIso()[nano_idx] > 1.49603193295) ||\
+		(pt < 10. && fabs(eta) >= 0.800 && fabs(eta) < 1.479 && nano.Electron_mvaHZZIso()[nano_idx] > 1.52414154008) ||\
+		(pt < 10. && fabs(eta) >= 1.479 && nano.Electron_mvaHZZIso()[nano_idx] > 1.77694249574)||\
+		(pt >= 10. && fabs(eta) < 0.800 && nano.Electron_mvaHZZIso()[nano_idx] > 0.199463934736) ||\
+		(pt >= 10. && fabs(eta) >= 0.800 && fabs(eta) < 1.479 && nano.Electron_mvaHZZIso()[nano_idx] > 0.076063564084) ||\
+		(pt >= 10. && fabs(eta) >= 1.479 && nano.Electron_mvaHZZIso()[nano_idx] > -0.572118857519));
       default:
         return nano.Electron_mvaIso_WP90()[nano_idx];
     }
@@ -180,6 +179,7 @@ vector<int> ElectronProducer::WriteElectrons(nano_tree &nano, pico_tree &pico, v
           pico.out_el_idLoose().push_back(nano.Electron_mvaIso_WP90()[iel]);
           pico.out_el_etPt().push_back(nano.Electron_scEtOverPt()[iel]);
           pico.out_el_eminusp().push_back(nano.Electron_eInvMinusPInv()[iel]);
+	  pico.out_el_fsrphotonidx().push_back(nano.Electron_fsrPhotonIdx()[iel]);
           break;
         default:
           std::cout<<"Need code for new year in getZGammaElBr (in el_producer.cpp)"<<endl;

--- a/src/el_producer.cpp
+++ b/src/el_producer.cpp
@@ -75,6 +75,7 @@ bool ElectronProducer::IsSignal(nano_tree &nano, int nano_idx, bool isZgamma) {
 		(pt >= 10. && fabs(etasc) >= 0.800 && fabs(etasc) < 1.479 && nano.Electron_mvaHZZIso()[nano_idx] > ConvertMVA(0.076063564084))|| \
 		(pt >= 10. && fabs(etasc) >= 1.479 && nano.Electron_mvaHZZIso()[nano_idx] > ConvertMVA(-0.572118857519)));
       default:
+	std::cout << "WARNING: year value not found in cases. Defaulting Electron MVA to WP90" << std::endl;
         return nano.Electron_mvaIso_WP90()[nano_idx];
     }
   }
@@ -277,7 +278,7 @@ bool ElectronProducer::idElectron_noIso(int bitmap, int level){
 }
 
 float ElectronProducer::ConvertMVA(float mva_mini) {
-  float mva_nano = 2.0 / (1.0 + exp(-2.0 * mva_mini) - 1);
+  float mva_nano = 2.0 / (1.0 + exp(-2.0 * mva_mini)) - 1;
   return mva_nano;
 }
 

--- a/src/generate_tree_classes.cxx
+++ b/src/generate_tree_classes.cxx
@@ -389,7 +389,7 @@ void WriteNanoSource(const vector<Variable> &vars){
   file << "void nano_tree::GetEntry(const long entry){\n";
   file << "  // Reset read-trackers for input branches \n";
   for(vector<Variable>::const_iterator var = vars.begin(); var!= vars.end(); ++var){
-    file << "  c_" << var->name_ << "_ = false;\n";
+    file << "  c_" << var->get_out_name() << "_ = false;\n";
   }
   file << "  entry_ = intree_->LoadTree(entry);\n";
   file << "}\n\n";
@@ -401,7 +401,7 @@ void WriteNanoSource(const vector<Variable> &vars){
     } else {
       file << var->type_ << " & nano_tree::" << var->get_out_name() << "(){\n";
     }
-    file << "  if(!c_" << var->name_ << "_ && b_" << var->get_out_name() <<"_){\n";
+    file << "  if(!c_" << var->get_out_name() << "_ && b_" << var->get_out_name() <<"_){\n";
     if (Contains(var->type_, "array")){
       file << "    int bytes = b_" << var->get_out_name() << "_->GetEntry(entry_);\n";
       file << "    "<< var->get_out_name() <<"_ = vector<"<< var->base_type_ <<">(arr_"<< var->get_out_name() <<"_.begin(), arr_"<< var->get_out_name() <<"_.begin()+bytes/sizeof(arr_"<< var->get_out_name() <<"_[0]));\n";

--- a/src/hig_producer.cpp
+++ b/src/hig_producer.cpp
@@ -18,14 +18,19 @@ HigVarProducer::~HigVarProducer(){
 }
 
 void HigVarProducer::WriteHigVars(pico_tree &pico, bool doDeepFlav, bool isSignal,
-                                  vector<HiggsConstructionVariables> sys_higvars){
+                                  vector<HiggsConstructionVariables> sys_higvars, float nanoaod_version){
 
   // get jet 4-vectors ordered by decreasing b-tag discriminator value,
   // also saving their original index in the pico.out_jet* vectors
   vector<pair<int, float>>  ordered_by_discr;
   for (unsigned ijet(0); ijet<pico.out_jet_pt().size(); ijet++) {
     if (pico.out_jet_isgood()[ijet]) {
-      float discr = doDeepFlav ? pico.out_jet_deepflav()[ijet] : pico.out_jet_deepcsv()[ijet];
+      float discr = -999;
+      if (nanoaod_version+0.01 < 12) {
+	discr = doDeepFlav ? pico.out_jet_deepflav()[ijet] : pico.out_jet_deepcsv()[ijet];
+      } else {
+	discr = doDeepFlav ? pico.out_jet_deepflav()[ijet] : pico.out_jet_btagpnetb()[ijet];
+      }
       ordered_by_discr.push_back(make_pair(ijet, discr));
     }
   }
@@ -95,8 +100,8 @@ void HigVarProducer::WriteHigVars(pico_tree &pico, bool doDeepFlav, bool isSigna
     }
   } //if at least 4 good jets
 
-  //make systematic variations
-  if (isSignal && !doDeepFlav) {
+  //make systematic variations. for now leave NanoAODv12
+  if (isSignal && !doDeepFlav && (nanoaod_version+0.01)<9) {
     pico.out_sys_hig_cand_dm().resize(4, -999.0);
     pico.out_sys_hig_cand_am().resize(4, -999.0);
     pico.out_sys_hig_cand_drmax().resize(4, -999.0);
@@ -107,8 +112,8 @@ void HigVarProducer::WriteHigVars(pico_tree &pico, bool doDeepFlav, bool isSigna
 
         vector<pair<TLorentzVector, float>> sys_ord_jet;
         for (unsigned ijet(0); ijet<sys_higvars[ijec].jet_lv.size(); ijet++) {
-          sys_ord_jet.push_back(make_pair(sys_higvars[ijec].jet_lv[ijet], 
-                                sys_higvars[ijec].jet_deepcsv[ijet]));
+	  sys_ord_jet.push_back(make_pair(sys_higvars[ijec].jet_lv[ijet], 
+					  sys_higvars[ijec].jet_deepcsv[ijet]));
         }
 
         sort(sys_ord_jet.begin(), sys_ord_jet.end(), 

--- a/src/isr_tools.cpp
+++ b/src/isr_tools.cpp
@@ -8,12 +8,13 @@
 
 using namespace std;
 
-ISRTools::ISRTools(const string &name_, int year_):
+ISRTools::ISRTools(const string &name_, int year_, float nanoaod_version_):
   name(name_),
   year(year_),
   isTTJets_LO(false),
   isGluino(false),
-  isTChi(false){
+  isTChi(false),
+  nanoaod_version(nanoaod_version_){
 
   if(Contains(name, "TTJets_") && Contains(name, "madgraphMLM")) 
     isTTJets_LO = true;
@@ -29,15 +30,20 @@ ISRTools::~ISRTools(){
 }
 
 bool ISRTools::IsLastCopyBeforeFSR_or_LastCopy(nano_tree & nano, int imc){
-  bitset<15> mc_statusFlags(nano.GenPart_statusFlags().at(imc));
-  int mc_mom_index = nano.GenPart_genPartIdxMother().at(imc);
+  vector<int> GenPart_statusFlags;
+  getGenPart_statusFlags(nano, nanoaod_version, GenPart_statusFlags);
+  vector<int> GenPart_genPartIdxMother;
+  getGenPart_genPartIdxMother(nano, nanoaod_version, GenPart_genPartIdxMother);
+
+  bitset<15> mc_statusFlags(GenPart_statusFlags.at(imc));
+  int mc_mom_index = GenPart_genPartIdxMother.at(imc);
   int mc_id = nano.GenPart_pdgId().at(imc);
 
   // 14: isLastCopyBeforeFSR
   // 13: isLastCopy
   if (mc_statusFlags[13] == 1) {
     if (mc_mom_index == -1) return true;
-    bitset<15> mom_statusFlags(nano.GenPart_statusFlags().at(mc_mom_index));
+    bitset<15> mom_statusFlags(GenPart_statusFlags.at(mc_mom_index));
     int mom_id = nano.GenPart_pdgId().at(mc_mom_index);
     // A lastCopyBeforeFSR exists
     if (mom_id == mc_id && mom_statusFlags[14] == 1) return false;
@@ -86,9 +92,11 @@ void ISRTools::WriteISRSystemPt(nano_tree &nano, pico_tree &pico) {
 
 std::map<int, std::vector<int> > ISRTools::GetChildMap(nano_tree & nano)
 {
+  vector<int> GenPart_genPartIdxMother;
+  getGenPart_genPartIdxMother(nano, nanoaod_version, GenPart_genPartIdxMother);
   map<int, vector<int> > child_map;
   for(int imc(0); imc<nano.nGenPart(); ++imc) {
-    int mc_mom_index = nano.GenPart_genPartIdxMother().at(imc);
+    int mc_mom_index = GenPart_genPartIdxMother.at(imc);
     child_map[mc_mom_index].push_back(imc);
   }
   return child_map;
@@ -97,7 +105,8 @@ std::map<int, std::vector<int> > ISRTools::GetChildMap(nano_tree & nano)
 void ISRTools::WriteISRJetMultiplicity(nano_tree &nano, pico_tree &pico) {
   bool verbose = false;
   map<int, vector<int> > child_map = GetChildMap(nano);
-
+  vector<int> GenPart_genPartIdxMother;
+  getGenPart_genPartIdxMother(nano, nanoaod_version, GenPart_genPartIdxMother);
   pico.out_nisr() = 0;
   for (size_t ijet(0); ijet<pico.out_jet_pt().size(); ijet++){
     if (!pico.out_jet_isgood()[ijet]) continue;
@@ -106,7 +115,7 @@ void ISRTools::WriteISRJetMultiplicity(nano_tree &nano, pico_tree &pico) {
     for (int imc(0); imc < nano.nGenPart(); imc++) {
       if (matched) break;
       if (nano.GenPart_status()[imc]!=23 || abs(nano.GenPart_pdgId()[imc])>5) continue;
-      int momid = abs(nano.GenPart_pdgId()[nano.GenPart_genPartIdxMother()[imc]]);
+      int momid = abs(nano.GenPart_pdgId()[GenPart_genPartIdxMother[imc]]);
       if(!(momid==6 || momid==23 || momid==24 || momid==25 || momid>1e6)) continue; 
       //check against daughter in case of hard initial splitting
       for (size_t idau(0); idau < child_map[imc].size(); idau++) {

--- a/src/jetmet_producer.cpp
+++ b/src/jetmet_producer.cpp
@@ -310,7 +310,6 @@ vector<int> JetMetProducer::WriteJetMet(nano_tree &nano, pico_tree &pico,
   pico.out_nbl() = 0; pico.out_nbm() = 0; pico.out_nbt() = 0; 
   pico.out_nbdfl() = 0; pico.out_nbdfm() = 0; pico.out_nbdft() = 0; 
   pico.out_ngenjet() = 0;
-
   //add smearing to jets and calculate uncertainties
   vector<float> Jet_pt, Jet_mass;
   vector<float> jer_nm_factor, jer_up_factor, jer_dn_factor, jes_up_factor, jes_dn_factor;
@@ -350,7 +349,14 @@ vector<int> JetMetProducer::WriteJetMet(nano_tree &nano, pico_tree &pico,
   }
   vector<int> Jet_jetId;
   getJetId(nano, nanoaod_version, Jet_jetId);
-  
+  vector<int> Jet_hadronFlavour;
+  getJet_hadronFlavour(nano, nanoaod_version, Jet_hadronFlavour);
+  vector<int> Jet_partonFlavour;
+  getJet_partonFlavour(nano, nanoaod_version, Jet_partonFlavour);
+  vector<int> Jet_genJetIdx;
+  if (!isData) getJet_genJetIdx(nano, nanoaod_version, Jet_genJetIdx);
+  vector<int> GenJet_partonFlavour;
+  if (!isData) getGenJet_partonFlavour(nano, nanoaod_version, GenJet_partonFlavour);
   // calculate MHT; needed when saving jet info
   TLorentzVector mht_vec;
   for(int ijet(0); ijet<nano.nJet(); ++ijet){
@@ -362,7 +368,6 @@ vector<int> JetMetProducer::WriteJetMet(nano_tree &nano, pico_tree &pico,
   }
   pico.out_mht() = mht_vec.Pt();
   pico.out_mht_phi() = mht_vec.Phi();
-
   vector<vector<float>> sys_jet_met_dphi;
   if ((nanoaod_version+0.01) < 9) {
     if (isSignal) {
@@ -497,7 +502,6 @@ vector<int> JetMetProducer::WriteJetMet(nano_tree &nano, pico_tree &pico,
       }
     }
 
-
     if (isvetojet) continue;
 
     if (Jet_pt[ijet] <= min_jet_pt && 
@@ -585,14 +589,13 @@ vector<int> JetMetProducer::WriteJetMet(nano_tree &nano, pico_tree &pico,
         std::cout<<"Need code for new year in getZGammaJetBr in jetmet_producer.cpp"<<endl;
         exit(1);
     }
-    if (!isData && nano.Jet_hadronFlavour().size() > 0) {
-      pico.out_jet_hflavor().push_back(nano.Jet_hadronFlavour()[ijet]);
-      pico.out_jet_pflavor().push_back(nano.Jet_partonFlavour()[ijet]);
-      pico.out_jet_genjet_idx().push_back(nano.Jet_genJetIdx()[ijet]);
+    if (!isData && Jet_hadronFlavour.size() > 0) {
+      pico.out_jet_hflavor().push_back(Jet_hadronFlavour[ijet]);
+      pico.out_jet_pflavor().push_back(Jet_partonFlavour[ijet]);
+      pico.out_jet_genjet_idx().push_back(Jet_genJetIdx[ijet]);
     }
     // will be overwritten with the overlapping fat jet index, if such exists, in WriteFatJets
     pico.out_jet_fjet_idx().push_back(-999);
-
     //the jets for the higgs pair with smallest dm will be set to true in hig_producer
     pico.out_jet_h1d().push_back(false);
     pico.out_jet_h2d().push_back(false);
@@ -617,7 +620,6 @@ vector<int> JetMetProducer::WriteJetMet(nano_tree &nano, pico_tree &pico,
       if (nano.Jet_btagDeepFlavB()[ijet] > btag_df_wpts[2]) pico.out_nbdft()++; 
     }
   } // end jet loop
-
   pico.out_low_dphi_mht_e5() = false;
   pico.out_low_dphi_met_e5() = false;
   for (unsigned ijet(0); ijet<pico.out_jet_mht_dphi().size(); ijet++){
@@ -655,7 +657,7 @@ vector<int> JetMetProducer::WriteJetMet(nano_tree &nano, pico_tree &pico,
       pico.out_genjet_eta().push_back(nano.GenJet_eta()[ijet]);
       pico.out_genjet_phi().push_back(nano.GenJet_phi()[ijet]);
       pico.out_genjet_m().push_back(nano.GenJet_mass()[ijet]);
-      pico.out_genjet_pflavor().push_back(nano.GenJet_partonFlavour()[ijet]);
+      pico.out_genjet_pflavor().push_back(GenJet_partonFlavour[ijet]);
       pico.out_genjet_hflavor().push_back(int(nano.GenJet_hadronFlavour()[ijet]));
     }
   }

--- a/src/jetmet_producer.cpp
+++ b/src/jetmet_producer.cpp
@@ -364,7 +364,6 @@ vector<int> JetMetProducer::WriteJetMet(nano_tree &nano, pico_tree &pico,
   pico.out_mht_phi() = mht_vec.Phi();
 
   vector<vector<float>> sys_jet_met_dphi;
-
   if ((nanoaod_version+0.01) < 9) {
     if (isSignal) {
       pico.out_sys_njet().resize(4,0);
@@ -413,7 +412,6 @@ vector<int> JetMetProducer::WriteJetMet(nano_tree &nano, pico_tree &pico,
     } else {
       phicorr = nano.Jet_phi().at(ijet);
     }
-
     if (fabs(nano.Jet_eta()[ijet])<5.191f) {
       if (year==2022 && is2022preEE==true){
         map_jetveto_ = cs_jetveto_->at("Winter22Run3_RunCD_V1");
@@ -430,7 +428,6 @@ vector<int> JetMetProducer::WriteJetMet(nano_tree &nano, pico_tree &pico,
 
     //don't include pt in isgood until later in order to save systematics
     bool isgood = !islep && !isphoton && (fabs(nano.Jet_eta()[ijet]) <= max_jet_eta) && pass_jetid && !isvetojet;
-
     //sys_jetvar convention: [0] JER up, [1] JER down, [2] JEC up, [3] JEC down
     //for now, only save sys_ variables
     if (isSignal && (nanoaod_version+0.01)<9) {
@@ -500,12 +497,13 @@ vector<int> JetMetProducer::WriteJetMet(nano_tree &nano, pico_tree &pico,
       }
     }
 
+
     if (isvetojet) continue;
+
     if (Jet_pt[ijet] <= min_jet_pt && 
         (Jet_pt[ijet]*jer_up_factor[ijet]/jer_nm_factor[ijet]) <= min_jet_pt &&
         (Jet_pt[ijet]*jer_dn_factor[ijet]/jer_nm_factor[ijet]) <= min_jet_pt &&
         (Jet_pt[ijet]*jes_up_factor[ijet]) <= min_jet_pt) continue;
-
     if (!isData && (nanoaod_version+0.01)>9 && isgood) {
       if ((Jet_pt[ijet]*jer_up_factor[ijet]/jer_nm_factor[ijet]) > min_jet_pt)
         pico.out_sys_njet()[0]++;
@@ -516,7 +514,6 @@ vector<int> JetMetProducer::WriteJetMet(nano_tree &nano, pico_tree &pico,
       if ((Jet_pt[ijet]*jes_dn_factor[ijet]) > min_jet_pt)
         pico.out_sys_njet()[3]++;
     }
-
     //after this point isgood means with nominal (smeared) pt
     isgood = isgood && (Jet_pt[ijet] >= min_jet_pt);
 
@@ -560,7 +557,9 @@ vector<int> JetMetProducer::WriteJetMet(nano_tree &nano, pico_tree &pico,
         pico.out_jet_m().push_back(Jet_mass[ijet]);
         //pico.out_jet_breg_corr().push_back(nano.Jet_bRegCorr()[ijet]);
         //pico.out_jet_breg_res().push_back(nano.Jet_bRegRes()[ijet]);
-        pico.out_jet_deepcsv().push_back(nano.Jet_btagDeepB()[ijet]);
+	//        pico.out_jet_deepcsv().push_back(nano.Jet_btagDeepB()[ijet]);
+	pico.out_jet_btagpnetb().push_back(nano.Jet_btagPNetB()[ijet]);
+	pico.out_jet_btagak4b().push_back(nano.Jet_btagRobustParTAK4B()[ijet]);
         pico.out_jet_deepflav().push_back(nano.Jet_btagDeepFlavB()[ijet]);
         pico.out_jet_ne_emef().push_back(nano.Jet_neEmEF()[ijet]);
         //pico.out_jet_qgl().push_back(nano.Jet_qgl()[ijet]);
@@ -586,13 +585,11 @@ vector<int> JetMetProducer::WriteJetMet(nano_tree &nano, pico_tree &pico,
         std::cout<<"Need code for new year in getZGammaJetBr in jetmet_producer.cpp"<<endl;
         exit(1);
     }
-
-    if (!isData) {
+    if (!isData && nano.Jet_hadronFlavour().size() > 0) {
       pico.out_jet_hflavor().push_back(nano.Jet_hadronFlavour()[ijet]);
       pico.out_jet_pflavor().push_back(nano.Jet_partonFlavour()[ijet]);
       pico.out_jet_genjet_idx().push_back(nano.Jet_genJetIdx()[ijet]);
     }
-    
     // will be overwritten with the overlapping fat jet index, if such exists, in WriteFatJets
     pico.out_jet_fjet_idx().push_back(-999);
 
@@ -606,9 +603,15 @@ vector<int> JetMetProducer::WriteJetMet(nano_tree &nano, pico_tree &pico,
       sig_jet_nano_idx.push_back(ijet);
       pico.out_njet()++;
       pico.out_ht() += Jet_pt[ijet];
-      if (nano.Jet_btagDeepB()[ijet] > btag_wpts[0]) pico.out_nbl()++; 
-      if (nano.Jet_btagDeepB()[ijet] > btag_wpts[1]) pico.out_nbm()++; 
-      if (nano.Jet_btagDeepB()[ijet] > btag_wpts[2]) pico.out_nbt()++;
+      if ((nanoaod_version+0.01) < 12){
+	if (nano.Jet_btagDeepB()[ijet] > btag_wpts[0]) pico.out_nbl()++; 
+	if (nano.Jet_btagDeepB()[ijet] > btag_wpts[1]) pico.out_nbm()++; 
+	if (nano.Jet_btagDeepB()[ijet] > btag_wpts[2]) pico.out_nbt()++;
+      } else {
+	if (nano.Jet_btagPNetB()[ijet] > btag_wpts[0]) pico.out_nbl()++;
+        if (nano.Jet_btagPNetB()[ijet] > btag_wpts[1]) pico.out_nbm()++;
+        if (nano.Jet_btagPNetB()[ijet] > btag_wpts[2]) pico.out_nbt()++;
+      }
       if (nano.Jet_btagDeepFlavB()[ijet] > btag_df_wpts[0]) pico.out_nbdfl()++; 
       if (nano.Jet_btagDeepFlavB()[ijet] > btag_df_wpts[1]) pico.out_nbdfm()++; 
       if (nano.Jet_btagDeepFlavB()[ijet] > btag_df_wpts[2]) pico.out_nbdft()++; 
@@ -644,7 +647,6 @@ vector<int> JetMetProducer::WriteJetMet(nano_tree &nano, pico_tree &pico,
       }
     }
   }
-
   // Saving GenJet information
   if (!isData) {
     pico.out_ngenjet() = nano.nGenJet();
@@ -657,7 +659,6 @@ vector<int> JetMetProducer::WriteJetMet(nano_tree &nano, pico_tree &pico,
       pico.out_genjet_hflavor().push_back(int(nano.GenJet_hadronFlavour()[ijet]));
     }
   }
-
   if (verbose) cout<<"Done with AK4 jets"<<endl;
   return sig_jet_nano_idx;
 }
@@ -765,7 +766,7 @@ void JetMetProducer::WriteSubJets(nano_tree &nano, pico_tree &pico){
 }
 
 void JetMetProducer::WriteJetSystemPt(nano_tree &nano, pico_tree &pico, 
-                                   vector<int> &sig_jet_nano_idx, const float &btag_wpt, bool isFastsim) {
+				      vector<int> &sig_jet_nano_idx, const float &btag_wpt, bool isFastsim){
 
   vector<float> Jet_pt, Jet_mass;
   getJetWithJEC(nano, isFastsim, Jet_pt, Jet_mass);
@@ -777,9 +778,16 @@ void JetMetProducer::WriteJetSystemPt(nano_tree &nano, pico_tree &pico,
     ijet_v4.SetPtEtaPhiM(Jet_pt[idx], nano.Jet_eta()[idx], nano.Jet_phi()[idx], Jet_mass[idx]);
     jetsys_v4 += ijet_v4;
 
-    if (nano.Jet_btagDeepB()[idx] <= btag_wpt){
-      njet_nob++;
-      jetsys_nob_v4 += ijet_v4;
+    if (nanoaod_version+0.1 < 12) {
+      if (nano.Jet_btagDeepB()[idx] <= btag_wpt){
+	njet_nob++;
+	jetsys_nob_v4 += ijet_v4;
+      }
+    } else {
+      if (nano.Jet_btagPNetB()[idx] <= btag_wpt){
+	njet_nob++;
+        jetsys_nob_v4 += ijet_v4;     
+      }
     }
   }
 

--- a/src/mu_producer.cpp
+++ b/src/mu_producer.cpp
@@ -52,6 +52,10 @@ vector<int> MuonProducer::WriteMuons(nano_tree &nano, pico_tree &pico, vector<in
   getJetWithJEC(nano, isFastsim, Jet_pt, Jet_mass);
   vector<int> Muon_fsrPhotonIdx;
   getMuon_fsrPhotonIdx(nano, nanoaod_version, Muon_fsrPhotonIdx);
+  vector<int> Muon_nTrackerLayers;
+  getMuon_nTrackerLayers(nano, nanoaod_version, Muon_nTrackerLayers);
+  vector<int> Muon_genPartIdx;;
+  getMuon_genPartIdx(nano, nanoaod_version, Muon_genPartIdx);
 
   //first, determine ordering based on signal and pt
   std::vector<NanoOrderEntry> nano_entries;
@@ -115,18 +119,17 @@ vector<int> MuonProducer::WriteMuons(nano_tree &nano, pico_tree &pico, vector<in
       pico.out_mu_corrected_ptErr().push_back(pt*rc.kScaleDTerror(nano.Muon_charge()[imu],pt,eta,nano.Muon_phi()[imu]));
     }
     else {
-      if (nano.Muon_genPartIdx()[imu] > 0 && nano.Muon_genPartIdx()[imu] < nano.nGenPart()) {
-        float gen_pt = nano.GenPart_pt()[nano.Muon_genPartIdx()[imu]];
+      if (Muon_genPartIdx[imu] > 0 && Muon_genPartIdx[imu] < nano.nGenPart()) {
+        float gen_pt = nano.GenPart_pt()[Muon_genPartIdx[imu]];
         pico.out_mu_corrected_pt().push_back(pt*rc.kSpreadMC(nano.Muon_charge()[imu],pt,eta,nano.Muon_phi()[imu],gen_pt));
         pico.out_mu_corrected_ptErr().push_back(pt*rc.kSpreadMCerror(nano.Muon_charge()[imu],pt,eta,nano.Muon_phi()[imu],gen_pt));
       }
       else {
         float unif_rand = rng.Uniform();
-        pico.out_mu_corrected_pt().push_back(pt*rc.kSmearMC(nano.Muon_charge()[imu],pt,eta,nano.Muon_phi()[imu],nano.Muon_nTrackerLayers()[imu],unif_rand));
-        pico.out_mu_corrected_ptErr().push_back(pt*rc.kSmearMCerror(nano.Muon_charge()[imu],pt,eta,nano.Muon_phi()[imu],nano.Muon_nTrackerLayers()[imu],unif_rand));
+        pico.out_mu_corrected_pt().push_back(pt*rc.kSmearMC(nano.Muon_charge()[imu],pt,eta,nano.Muon_phi()[imu],Muon_nTrackerLayers[imu],unif_rand));
+        pico.out_mu_corrected_ptErr().push_back(pt*rc.kSmearMCerror(nano.Muon_charge()[imu],pt,eta,nano.Muon_phi()[imu],Muon_nTrackerLayers[imu],unif_rand));
       }
     }
-
     if (!isData)
       pico.out_mu_pflavor().push_back(nano.Muon_genPartFlav()[imu]);
 

--- a/src/photon_producer.cpp
+++ b/src/photon_producer.cpp
@@ -284,6 +284,7 @@ vector<int> PhotonProducer::WritePhotons(nano_tree &nano, pico_tree &pico, vecto
     pico.out_fsrphoton_reliso().push_back(nano.FsrPhoton_relIso03()[iph]);
     pico.out_fsrphoton_muonidx().push_back(FsrPhoton_muonIdx[iph]);
     pico.out_fsrphoton_droveret2().push_back(nano.FsrPhoton_dROverEt2()[iph]);
+    if (nanoaod_version +0.01 > 12) pico.out_fsrphoton_electronidx().push_back(nano.FsrPhoton_electronIdx()[iph]);
     pico.out_nfsrphoton()++;
   } 
 

--- a/src/process_nano.cxx
+++ b/src/process_nano.cxx
@@ -221,7 +221,7 @@ int main(int argc, char *argv[]){
 
   // B-tag working points
   // Updated Values May-28-2024 from https://btv-wiki.docs.cern.ch/ScaleFactors/
-  // btag_df: Run 3 values are for PNet, Run 2 values are for deepCSV
+  // btag_df: WPs for deepJet (DeepFlavourB)
   map<string, vector<float>> btag_df_wpts{
     {"2016APV", vector<float>({0.0508, 0.2598, 0.6502})},
     {"2016", vector<float>({0.0480, 0.2489, 0.6377})},
@@ -232,7 +232,7 @@ int main(int argc, char *argv[]){
     {"2023", vector<float>({0.0479, 0.2431, 0.6553})},
     {"2023BPix", vector<float>({0.048, 0.2435, 0.6563})}
   };
-  // WPs for deepJet
+  // WPs for Run 3 values are for PNet, Run 2 values are for deepCSV (DeepB)
   map<string, vector<float>> btag_wpts{
     {"2016APV", vector<float>({0.2027, 0.6001, 0.8819})},
     {"2016", vector<float>({0.1918, 0.5847, 0.8767})},

--- a/src/process_nano.cxx
+++ b/src/process_nano.cxx
@@ -220,6 +220,8 @@ int main(int argc, char *argv[]){
   if(isZgamma) max_jet_eta  =  4.7;
 
   // B-tag working points
+  // Updated Values May-28-2024 from https://btv-wiki.docs.cern.ch/ScaleFactors/
+  // btag_df: Run 3 values are for PNet, Run 2 values are for deepCSV
   map<string, vector<float>> btag_df_wpts{
     {"2016APV", vector<float>({0.0508, 0.2598, 0.6502})},
     {"2016", vector<float>({0.0480, 0.2489, 0.6377})},
@@ -230,7 +232,7 @@ int main(int argc, char *argv[]){
     {"2023", vector<float>({0.0479, 0.2431, 0.6553})},
     {"2023BPix", vector<float>({0.048, 0.2435, 0.6563})}
   };
-
+  // WPs for deepJet
   map<string, vector<float>> btag_wpts{
     {"2016APV", vector<float>({0.2027, 0.6001, 0.8819})},
     {"2016", vector<float>({0.1918, 0.5847, 0.8767})},

--- a/src/process_nano.cxx
+++ b/src/process_nano.cxx
@@ -220,18 +220,22 @@ int main(int argc, char *argv[]){
   if(isZgamma) max_jet_eta  =  4.7;
 
   // B-tag working points
-  map<int, vector<float>> btag_df_wpts{
-    {2016, vector<float>({0.0614, 0.3093, 0.7221})},
-    {2017, vector<float>({0.0521, 0.3033, 0.7489})},
-    {2018, vector<float>({0.0494, 0.2770, 0.7264})},
-    {2022, vector<float>({0.0494, 0.2770, 0.7264})},
-    {2023, vector<float>({0.0494, 0.2770, 0.7264})}
+  map<string, vector<float>> btag_df_wpts{
+    {"2016APV", vector<float>({0.0508, 0.2598, 0.6502})},
+    {"2016", vector<float>({0.0480, 0.2489, 0.6377})},
+    {"2017", vector<float>({0.0532, 0.3040, 0.7476})},
+    {"2018", vector<float>({0.0490, 0.2783, 0.7100})},
+    {"2022", vector<float>({0.0583, 0.3086, 0.7183})},
+    {"2022EE", vector<float>({0.0614, 0.3196, 0.73})},
+    {"2023", vector<float>({0.0479, 0.2431, 0.6553})},
+    {"2023BPix", vector<float>({0.048, 0.2435, 0.6563})}
   };
 
   map<string, vector<float>> btag_wpts{
-    {"2016", vector<float>({0.2217, 0.6321, 0.8953})},
-    {"2017", vector<float>({0.1522, 0.4941, 0.8001})},
-    {"2018", vector<float>({0.1241, 0.4184, 0.7527})},
+    {"2016APV", vector<float>({0.2027, 0.6001, 0.8819})},
+    {"2016", vector<float>({0.1918, 0.5847, 0.8767})},
+    {"2017", vector<float>({0.1355, 0.4506, 0.7738})},
+    {"2018", vector<float>({0.1208, 0.4168, 0.7665})},
     {"2022", vector<float>({0.047,  0.245,  0.6734})},
     {"2022EE", vector<float>({0.0499, 0.2605, 0.6915})},  
     {"2023", vector<float>({0.0358, 0.1917, 0.6172})},
@@ -282,12 +286,12 @@ int main(int argc, char *argv[]){
   // Pre-UL scale factors
   const vector<BTagEntry::OperatingPoint> op_all = {BTagEntry::OP_LOOSE, BTagEntry::OP_MEDIUM, BTagEntry::OP_TIGHT};
   BTagWeighter btag_weighter(year, isFastsim, false, btag_wpts[year_string]);
-  BTagWeighter btag_df_weighter(year, isFastsim, true, btag_df_wpts[year]);
+  BTagWeighter btag_df_weighter(year, isFastsim, true, btag_df_wpts[year_string]);
   LeptonWeighter lep_weighter(year, isZgamma);
   LeptonWeighter lep_weighter16gh(year, isZgamma, true);
   PhotonWeighter photon_weighter(year, isZgamma || isHiggsino);
   // UL scale factors
-  EventWeighter event_weighter(year_string, btag_df_wpts[year]);
+  EventWeighter event_weighter(year_string, btag_df_wpts[year_string]);
   TriggerWeighter trigger_weighter(year, isAPV);
   //cout<<"Is APV: "<<isAPV<<endl;
 
@@ -405,7 +409,7 @@ int main(int argc, char *argv[]){
     vector<HiggsConstructionVariables> sys_higvars;
     vector<int> sig_jet_nano_idx = jetmet_producer.WriteJetMet(nano, pico, 
         jet_islep_nano_idx, jet_isvlep_nano_idx, jet_isphoton_nano_idx,
-        btag_wpts[year_string], btag_df_wpts[year], isFastsim, isSignal, 
+        btag_wpts[year_string], btag_df_wpts[year_string], isFastsim, isSignal, 
         is2022preEE, sys_higvars);
     jetmet_producer.WriteJetSystemPt(nano, pico, sig_jet_nano_idx, btag_wpts[year_string][1], isFastsim); // usually w.r.t. medium WP
     jetmet_producer.WriteFatJets(nano, pico); // jetmet_producer.SetVerbose(nano.nSubJet()>0);

--- a/src/process_nano.cxx
+++ b/src/process_nano.cxx
@@ -264,7 +264,7 @@ int main(int argc, char *argv[]){
   }
 
   //Initialize object producers
-  GenParticleProducer mc_producer(year);
+  GenParticleProducer mc_producer(year, nanoaod_version);
   ElectronProducer el_producer(year, isData, isAPV, nanoaod_version);
   MuonProducer mu_producer(year, isData, nanoaod_version, rocco_file);
   DileptonProducer dilep_producer(year);
@@ -299,7 +299,7 @@ int main(int argc, char *argv[]){
   EventTools event_tools(in_path, year, isData, nanoaod_version);
   int event_type = event_tools.GetEventType();
 
-  ISRTools isr_tools(in_path, year);
+  ISRTools isr_tools(in_path, year, nanoaod_version);
 
   // Initialize trees
   nano_tree nano(in_path, nanoaod_version);

--- a/src/process_nano.cxx
+++ b/src/process_nano.cxx
@@ -210,6 +210,7 @@ int main(int argc, char *argv[]){
     if (is_nanoAODv7_found) nanoaod_version = 7;
   }
   if (Contains(in_dir, "NanoAODv9UCSB")) nanoaod_version = 9.5;
+  if (Contains(in_dir, "NanoAODv12")) nanoaod_version = 12;
   cout<<"Using NanoAOD version: "<<nanoaod_version<<endl;
 
   time_t begtime, endtime;
@@ -219,19 +220,22 @@ int main(int argc, char *argv[]){
   if(isZgamma) max_jet_eta  =  4.7;
 
   // B-tag working points
-  map<int, vector<float>> btag_wpts{
-    {2016, vector<float>({0.2217, 0.6321, 0.8953})},
-    {2017, vector<float>({0.1522, 0.4941, 0.8001})},
-    {2018, vector<float>({0.1241, 0.4184, 0.7527})},
-    {2022, vector<float>({0.1241, 0.4184, 0.7527})},
-    {2023, vector<float>({0.1241, 0.4184, 0.7527})}
-  };
   map<int, vector<float>> btag_df_wpts{
     {2016, vector<float>({0.0614, 0.3093, 0.7221})},
     {2017, vector<float>({0.0521, 0.3033, 0.7489})},
     {2018, vector<float>({0.0494, 0.2770, 0.7264})},
     {2022, vector<float>({0.0494, 0.2770, 0.7264})},
     {2023, vector<float>({0.0494, 0.2770, 0.7264})}
+  };
+
+  map<string, vector<float>> btag_wpts{
+    {"2016", vector<float>({0.2217, 0.6321, 0.8953})},
+    {"2017", vector<float>({0.1522, 0.4941, 0.8001})},
+    {"2018", vector<float>({0.1241, 0.4184, 0.7527})},
+    {"2022", vector<float>({0.047,  0.245,  0.6734})},
+    {"2022EE", vector<float>({0.0499, 0.2605, 0.6915})},  
+    {"2023", vector<float>({0.0358, 0.1917, 0.6172})},
+    {"2023BPix", vector<float>({0.0359, 0.1919, 0.6133})}
   };
 
   // Rochester corrections
@@ -277,7 +281,7 @@ int main(int argc, char *argv[]){
   PrefireWeighter prefire_weighter(year, true);
   // Pre-UL scale factors
   const vector<BTagEntry::OperatingPoint> op_all = {BTagEntry::OP_LOOSE, BTagEntry::OP_MEDIUM, BTagEntry::OP_TIGHT};
-  BTagWeighter btag_weighter(year, isFastsim, false, btag_wpts[year]);
+  BTagWeighter btag_weighter(year, isFastsim, false, btag_wpts[year_string]);
   BTagWeighter btag_df_weighter(year, isFastsim, true, btag_df_wpts[year]);
   LeptonWeighter lep_weighter(year, isZgamma);
   LeptonWeighter lep_weighter16gh(year, isZgamma, true);
@@ -330,7 +334,6 @@ int main(int argc, char *argv[]){
     if (isData && !passed_trig) {
       continue;
     }
-
     // event info
     pico.out_event()     = nano.event();
     pico.out_lumiblock() = nano.luminosityBlock();
@@ -362,9 +365,9 @@ int main(int argc, char *argv[]){
     vector<int> sig_el_pico_idx = vector<int>();
     vector<int> sig_mu_pico_idx = vector<int>();
     vector<int> photon_el_pico_idx = vector<int>();
+    
     vector<int> sig_el_nano_idx = el_producer.WriteElectrons(nano, pico, jet_islep_nano_idx, jet_isvlep_nano_idx, sig_el_pico_idx, photon_el_pico_idx, isZgamma, isFastsim);
     vector<int> sig_mu_nano_idx = mu_producer.WriteMuons(nano, pico, jet_islep_nano_idx, jet_isvlep_nano_idx, sig_mu_pico_idx, isZgamma, isFastsim);
-
     // save a separate vector with just signal leptons ordered by pt
     struct SignalLepton{ float pt; float eta; float phi; int pdgid;};
     vector<SignalLepton> sig_leps;
@@ -383,17 +386,13 @@ int main(int argc, char *argv[]){
       pico.out_lep_phi().push_back(ilep.phi);
       pico.out_lep_pdgid().push_back(ilep.pdgid);
     }
-
     vector<int> jet_isphoton_nano_idx = vector<int>();
     if(isZgamma || isHiggsino) 
       vector<int> sig_ph_nano_idx = photon_producer.WritePhotons(nano, pico, jet_isphoton_nano_idx,
                                                                  sig_el_nano_idx, sig_mu_nano_idx,
                                                                  photon_el_pico_idx);
-
     event_tools.WriteStitch(nano, pico);
- 
     tk_producer.WriteIsoTracks(nano, pico, sig_el_nano_idx, sig_mu_nano_idx, isFastsim, is_preUL);
-
     dilep_producer.WriteDileptons(pico, sig_el_pico_idx, sig_mu_pico_idx);
 
     if (debug) cout<<"INFO:: Writing gen particles"<<endl;
@@ -406,9 +405,9 @@ int main(int argc, char *argv[]){
     vector<HiggsConstructionVariables> sys_higvars;
     vector<int> sig_jet_nano_idx = jetmet_producer.WriteJetMet(nano, pico, 
         jet_islep_nano_idx, jet_isvlep_nano_idx, jet_isphoton_nano_idx,
-        btag_wpts[year], btag_df_wpts[year], isFastsim, isSignal, 
+        btag_wpts[year_string], btag_df_wpts[year], isFastsim, isSignal, 
         is2022preEE, sys_higvars);
-    jetmet_producer.WriteJetSystemPt(nano, pico, sig_jet_nano_idx, btag_wpts[year][1], isFastsim); // usually w.r.t. medium WP
+    jetmet_producer.WriteJetSystemPt(nano, pico, sig_jet_nano_idx, btag_wpts[year_string][1], isFastsim); // usually w.r.t. medium WP
     jetmet_producer.WriteFatJets(nano, pico); // jetmet_producer.SetVerbose(nano.nSubJet()>0);
     jetmet_producer.WriteSubJets(nano, pico);
     isr_tools.WriteISRJetMultiplicity(nano, pico);
@@ -426,6 +425,7 @@ int main(int argc, char *argv[]){
           nano.Muon_pt()[sig_mu_nano_idx[0]], nano.Muon_phi()[sig_mu_nano_idx[0]]);
       }
     } 
+
     if (pico.out_ntrulep()==1) {
       for (unsigned imc(0); imc<pico.out_mc_id().size(); imc++){
         if (abs(pico.out_mc_id()[imc])==11 || abs(pico.out_mc_id()[imc])==13) {
@@ -439,12 +439,10 @@ int main(int argc, char *argv[]){
         }
       }
     } 
-
     if (debug) cout<<"INFO:: Writing analysis specific variables"<<endl;
     // might need as input sig_el_nano_idx, sig_mu_nano_idx, sig_ph_nano_idx
     if(isZgamma)
       zgamma_producer.WriteZGammaVars(nano, pico, sig_jet_nano_idx);
-
   
     if (isHiggsino) gammagamma_producer.WriteGammaGammaVars(pico);
     if (isHiggsino) bb_producer.WriteBBVars(pico, /*doDeepFlav*/false);
@@ -452,8 +450,8 @@ int main(int argc, char *argv[]){
     if (isHiggsino) bbgammagamma_producer.WriteBBGammaGammaVars(pico);
 
     //save higgs variables using DeepCSV and DeepFlavor
-    hig_producer.WriteHigVars(pico, false, isSignal, sys_higvars);
-    hig_producer.WriteHigVars(pico, true, isSignal, sys_higvars);
+    hig_producer.WriteHigVars(pico, false, isSignal, sys_higvars, nanoaod_version);
+    hig_producer.WriteHigVars(pico, true, isSignal, sys_higvars, nanoaod_version);
 
     if (debug) cout<<"INFO:: Writing filters and triggers"<<endl;
     // N.B. Jets: pico.out_pass_jets() and pico.out_pass_fsjets() filled in jetmet_producer
@@ -655,7 +653,7 @@ int main(int argc, char *argv[]){
         wgt_sums.out_sys_ps()[i] += pico.out_sys_ps()[i];
       }
     }
-
+    
     if (debug) cout<<"INFO:: Filling tree"<<endl;
     pico.Fill();
   } // loop over events

--- a/src/utilities.cpp
+++ b/src/utilities.cpp
@@ -381,3 +381,67 @@ void getFatJet_subJetIdx2(nano_tree & nano, float nanoaod_version, vector<int> &
     else FatJet_subJetIdx2[ipart] = nano.FatJet_subJetIdx2()[ipart];
   }
 }
+
+void getMuon_nTrackerLayers(nano_tree & nano, float nanoaod_version, vector<int> & Muon_nTrackerLayers) {
+  Muon_nTrackerLayers.resize(nano.nMuon());
+  for(int ipart(0); ipart<nano.nMuon(); ++ipart){
+    if (nanoaod_version+0.01 > 12) Muon_nTrackerLayers[ipart] = nano.Muon_nTrackerLayers_12p0()[ipart];
+    else Muon_nTrackerLayers[ipart] = nano.Muon_nTrackerLayers()[ipart];
+  }
+}
+
+void getMuon_genPartIdx(nano_tree & nano, float nanoaod_version, vector<int> & Muon_genPartIdx) {
+  Muon_genPartIdx.resize(nano.nMuon());
+  for(int ipart(0); ipart<nano.nMuon(); ++ipart){
+    if (nanoaod_version+0.01 > 12) Muon_genPartIdx[ipart] = nano.Muon_genPartIdx_12p0()[ipart];                                                                                                                                          
+    else Muon_genPartIdx[ipart] = nano.Muon_genPartIdx()[ipart];                                                                                                                                                                         
+  }
+}
+
+void getJet_genJetIdx(nano_tree & nano, float nanoaod_version, vector<int> & Jet_genJetIdx) {
+  Jet_genJetIdx.resize(nano.nJet());
+  for(int ipart(0); ipart<nano.nJet(); ++ipart){
+    if (nanoaod_version+0.01 > 12) Jet_genJetIdx[ipart] = nano.Jet_genJetIdx_12p0()[ipart];
+    else Jet_genJetIdx[ipart] = nano.Jet_genJetIdx()[ipart];
+  }
+}
+
+void getJet_hadronFlavour(nano_tree & nano, float nanoaod_version, vector<int> & Jet_hadronFlavour) {
+  Jet_hadronFlavour.resize(nano.nJet());
+  for(int ipart(0); ipart<nano.nJet(); ++ipart){
+    if (nanoaod_version+0.01 > 12) Jet_hadronFlavour[ipart] = nano.Jet_hadronFlavour_12p0()[ipart];
+    else Jet_hadronFlavour[ipart] = nano.Jet_hadronFlavour()[ipart];
+  }
+}
+
+void getJet_partonFlavour(nano_tree & nano, float nanoaod_version, vector<int> & Jet_partonFlavour) {
+  Jet_partonFlavour.resize(nano.nJet());
+  for(int ipart(0); ipart<nano.nJet(); ++ipart){
+    if (nanoaod_version+0.01 > 12) Jet_partonFlavour[ipart] = nano.Jet_partonFlavour_12p0()[ipart];
+    else Jet_partonFlavour[ipart] = nano.Jet_partonFlavour()[ipart];
+  }
+}
+
+void getGenPart_genPartIdxMother(nano_tree & nano, float nanoaod_version, vector<int> & GenPart_genPartIdxMother) {
+  GenPart_genPartIdxMother.resize(nano.nGenPart());
+  for(int ipart(0); ipart<nano.nGenPart(); ++ipart){
+    if (nanoaod_version+0.01 > 12) GenPart_genPartIdxMother[ipart] = nano.GenPart_genPartIdxMother_12p0()[ipart];
+    else GenPart_genPartIdxMother[ipart] = nano.GenPart_genPartIdxMother()[ipart];
+  }
+}
+
+void getGenPart_statusFlags(nano_tree & nano, float nanoaod_version, vector<int> & GenPart_statusFlags) {
+  GenPart_statusFlags.resize(nano.nGenPart());                                                                                                                                                                                                    
+  for(int ipart(0); ipart<nano.nGenPart(); ++ipart){
+    if (nanoaod_version+0.01 > 12) GenPart_statusFlags[ipart] = nano.GenPart_statusFlags_12p0()[ipart];                                                                                                                                  
+    else GenPart_statusFlags[ipart] = nano.GenPart_statusFlags()[ipart];                                                                                                                                                                 
+  }
+}
+
+void getGenJet_partonFlavour(nano_tree & nano, float nanoaod_version, vector<int> & GenJet_partonFlavour) {
+  GenJet_partonFlavour.resize(nano.nGenJet());
+  for(int ipart(0); ipart<nano.nGenJet(); ++ipart){
+    if (nanoaod_version+0.01 > 12) GenJet_partonFlavour[ipart] = nano.GenJet_partonFlavour_12p0()[ipart];
+    else GenJet_partonFlavour[ipart] = nano.GenJet_partonFlavour()[ipart];
+  }
+}

--- a/txt/variables/nano
+++ b/txt/variables/nano
@@ -97,7 +97,6 @@ array<float> Electron_mvaHZZIso
 array<float> Electron_mvaNoIso
 array<bool> Electron_mvaNoIso_WP80
 array<bool> Electron_mvaNoIso_WP90
-array<float> Electron_eCorr
 array<short> Electron_fsrPhotonIdx
 array<char> Electron_seediEtaOriX
 array<int> Electron_seediPhiOriY
@@ -136,12 +135,12 @@ array<int> Muon_charge
 array<int> Muon_jetIdx
 array<short> Muon_jetIdx 12.0
 array<int> Muon_nStations
-array<uchar> Muon_nStations 12.0
+array<char> Muon_nStations 12.0
 array<int> Muon_nTrackerLayers
-array<uchar> Muon_nTrackerLayers 12.0
+array<char> Muon_nTrackerLayers 12.0
 array<int> Muon_pdgId
 array<int> Muon_tightCharge
-array<uchar> Muon_tightCharge 12.0
+array<char> Muon_tightCharge 12.0
 array<char> Muon_highPtId
 array<bool> Muon_inTimeMuon
 array<bool> Muon_isGlobal
@@ -164,9 +163,8 @@ array<short> Muon_genPartIdx 12.0
 array<char> Muon_genPartFlav
 array<char> Muon_cleanmask
 #NanoAODv12
-array<float> Muon_mvaLowPt
 array<float> Muon_mvaMuID
-array<uchar> Muon_mvaMuID_WP
+array<char> Muon_mvaMuID_WP
 array<float> Muon_bsConstrainedChi2
 array<float> Muon_bsConstrainedPt
 array<float> Muon_bsConstrainedPtErr
@@ -331,19 +329,28 @@ array<float> Jet_rawFactor
 array<float> Jet_bRegCorr
 array<float> Jet_bRegRes
 array<int> Jet_electronIdx1
+array<short> Jet_electronIdx1 12
 array<int> Jet_electronIdx2
+array<short> Jet_electronIdx2 12
 array<int> Jet_jetId
 array<char> Jet_jetId 11.9
 array<int> Jet_muonIdx1
+array<short> Jet_muonIdx1 12
 array<int> Jet_muonIdx2
+array<short> Jet_muonIdx2 12
 array<int> Jet_nConstituents
 array<int> Jet_nElectrons
+array<char> Jet_nElectrons 12
 array<int> Jet_nMuons
+array<char> Jet_nMuons 12
 array<int> Jet_puId
 array<float> Jet_puIdDisc
 array<int> Jet_genJetIdx
+array<short> Jet_genJetIdx 12
 array<int> Jet_hadronFlavour
+array<char> Jet_hadronFlavour 12
 array<int> Jet_partonFlavour
+array<short> Jet_partonFlavour 12
 array<char> Jet_cleanmask
 array<float> Jet_pt_jerUp
 array<float> Jet_pt_jerDown
@@ -353,6 +360,19 @@ array<float> Jet_mass_jerUp
 array<float> Jet_mass_jerDown
 array<float> Jet_mass_jesTotalUp
 array<float> Jet_mass_jesTotalDown
+#NanoAODv12
+array<float> Jet_PNetRegPtRawCorr
+array<float> Jet_PNetRegPtRawCorrNeutrino
+array<float> Jet_PNetRegPtRawRes
+array<float> Jet_btagPNetB
+array<float> Jet_btagPNetCvB
+array<float> Jet_btagPNetCvL
+array<float> Jet_btagPNetQvG
+array<float> Jet_btagPNetTauVarrayJet
+array<float> Jet_btagRobustParTAK4B
+array<float> Jet_btagRobustParTAK4CvB
+array<float> Jet_btagRobustParTAK4CvL
+array<float> Jet_btagRobustParTAK4QG
 
 ################ Very soft Jets ################
 
@@ -617,9 +637,9 @@ float PV_z
 float PV_chi2
 float PV_score
 int PV_npvs
-uchar PV_npvs 12.0
+char PV_npvs 12.0
 int PV_npvsGood
-uchar PV_npvsGood 12.0
+char PV_npvsGood 12.0
 
 ################ Secondary vertices ################
 int nSV

--- a/txt/variables/nano
+++ b/txt/variables/nano
@@ -561,6 +561,7 @@ array<float> GenJet_phi
 array<float> GenJet_pt
 array<char> GenJet_hadronFlavour
 array<int> GenJet_partonFlavour
+array<short> GenJet_partonFlavour 12.0
 
 int nGenJetAK8
 array<float> GenJetAK8_eta

--- a/txt/variables/nano
+++ b/txt/variables/nano
@@ -61,12 +61,12 @@ array<float> Electron_scEtOverPt
 array<int> Electron_cutBased
 array<int> Electron_cutBased_Fall17_V1
 array<int> Electron_jetIdx
-array<short> Electron_jetIdx 12.0
+array<short> Electron_jetIdx 12
 array<int> Electron_pdgId
 array<int> Electron_photonIdx
 array<short> Electron_photonIdx 11.9
 array<int> Electron_tightCharge
-array<UChar_t> Electron_tightCharge 12.0
+array<UChar_t> Electron_tightCharge 12
 array<int> Electron_vidNestedWPBitmap
 array<int> Electron_vidNestedWPBitmapHEEP
 array<bool> Electron_convVeto
@@ -89,7 +89,7 @@ array<bool> Electron_mvaIso_WP80
 array<bool> Electron_mvaIso_WP90
 array<char> Electron_seedGain
 array<int> Electron_genPartIdx
-array<short> Electron_genPartIdx 12.0
+array<short> Electron_genPartIdx 12
 array<char> Electron_genPartFlav
 array<char> Electron_cleanmask
 # NanoAODv12
@@ -133,14 +133,14 @@ array<int> Muon_fsrPhotonIdx
 array<short> Muon_fsrPhotonIdx 11.9
 array<int> Muon_charge
 array<int> Muon_jetIdx
-array<short> Muon_jetIdx 12.0
+array<short> Muon_jetIdx 12
 array<int> Muon_nStations
-array<char> Muon_nStations 12.0
+array<char> Muon_nStations 12
 array<int> Muon_nTrackerLayers
-array<char> Muon_nTrackerLayers 12.0
+array<char> Muon_nTrackerLayers 12
 array<int> Muon_pdgId
 array<int> Muon_tightCharge
-array<char> Muon_tightCharge 12.0
+array<char> Muon_tightCharge 12
 array<char> Muon_highPtId
 array<bool> Muon_inTimeMuon
 array<bool> Muon_isGlobal
@@ -159,7 +159,7 @@ array<bool> Muon_tightId
 array<char> Muon_tkIsoId
 array<bool> Muon_triggerIdLoose
 array<int> Muon_genPartIdx
-array<short> Muon_genPartIdx 12.0
+array<short> Muon_genPartIdx 12
 array<char> Muon_genPartFlav
 array<char> Muon_cleanmask
 #NanoAODv12
@@ -283,7 +283,7 @@ array<bool> Photon_mvaID_WP90
 array<bool> Photon_pixelSeed
 array<char> Photon_seedGain
 array<int> Photon_genPartIdx
-array<short> Photon_genPartIdx 12.0
+array<short> Photon_genPartIdx 12
 array<char> Photon_genPartFlav
 array<char> Photon_cleanmask
 
@@ -531,11 +531,11 @@ array<float> GenPart_mass
 array<float> GenPart_phi
 array<float> GenPart_pt
 array<int> GenPart_genPartIdxMother
-array<short> GenPart_genPartIdxMother 12.0
+array<short> GenPart_genPartIdxMother 12
 array<int> GenPart_pdgId
 array<int> GenPart_status
 array<int> GenPart_statusFlags
-array<ushort> GenPart_statusFlags 12.0
+array<ushort> GenPart_statusFlags 12
 
 int nGenDressedLepton
 array<float> GenDressedLepton_eta
@@ -561,7 +561,7 @@ array<float> GenJet_phi
 array<float> GenJet_pt
 array<char> GenJet_hadronFlavour
 array<int> GenJet_partonFlavour
-array<short> GenJet_partonFlavour 12.0
+array<short> GenJet_partonFlavour 12
 
 int nGenJetAK8
 array<float> GenJetAK8_eta
@@ -638,9 +638,9 @@ float PV_z
 float PV_chi2
 float PV_score
 int PV_npvs
-char PV_npvs 12.0
+char PV_npvs 12
 int PV_npvsGood
-char PV_npvsGood 12.0
+char PV_npvsGood 12
 
 ################ Secondary vertices ################
 int nSV

--- a/txt/variables/nano
+++ b/txt/variables/nano
@@ -61,10 +61,12 @@ array<float> Electron_scEtOverPt
 array<int> Electron_cutBased
 array<int> Electron_cutBased_Fall17_V1
 array<int> Electron_jetIdx
+array<short> Electron_jetIdx 12.0
 array<int> Electron_pdgId
 array<int> Electron_photonIdx
 array<short> Electron_photonIdx 11.9
 array<int> Electron_tightCharge
+array<UChar_t> Electron_tightCharge 12.0
 array<int> Electron_vidNestedWPBitmap
 array<int> Electron_vidNestedWPBitmapHEEP
 array<bool> Electron_convVeto
@@ -87,8 +89,19 @@ array<bool> Electron_mvaIso_WP80
 array<bool> Electron_mvaIso_WP90
 array<char> Electron_seedGain
 array<int> Electron_genPartIdx
+array<short> Electron_genPartIdx 12.0
 array<char> Electron_genPartFlav
 array<char> Electron_cleanmask
+# NanoAODv12
+array<float> Electron_mvaHZZIso
+array<float> Electron_mvaNoIso
+array<bool> Electron_mvaNoIso_WP80
+array<bool> Electron_mvaNoIso_WP90
+array<float> Electron_eCorr
+array<short> Electron_fsrPhotonIdx
+array<char> Electron_seediEtaOriX
+array<int> Electron_seediPhiOriY
+array<short> Electron_svIdx
 
 ################ Muons ################
 
@@ -121,10 +134,14 @@ array<int> Muon_fsrPhotonIdx
 array<short> Muon_fsrPhotonIdx 11.9
 array<int> Muon_charge
 array<int> Muon_jetIdx
+array<short> Muon_jetIdx 12.0
 array<int> Muon_nStations
+array<uchar> Muon_nStations 12.0
 array<int> Muon_nTrackerLayers
+array<uchar> Muon_nTrackerLayers 12.0
 array<int> Muon_pdgId
 array<int> Muon_tightCharge
+array<uchar> Muon_tightCharge 12.0
 array<char> Muon_highPtId
 array<bool> Muon_inTimeMuon
 array<bool> Muon_isGlobal
@@ -143,8 +160,17 @@ array<bool> Muon_tightId
 array<char> Muon_tkIsoId
 array<bool> Muon_triggerIdLoose
 array<int> Muon_genPartIdx
+array<short> Muon_genPartIdx 12.0
 array<char> Muon_genPartFlav
 array<char> Muon_cleanmask
+#NanoAODv12
+array<float> Muon_mvaLowPt
+array<float> Muon_mvaMuID
+array<uchar> Muon_mvaMuID_WP
+array<float> Muon_bsConstrainedChi2
+array<float> Muon_bsConstrainedPt
+array<float> Muon_bsConstrainedPtErr
+array<short> Muon_svIdx
 
 ################ Taus ################
 
@@ -259,6 +285,7 @@ array<bool> Photon_mvaID_WP90
 array<bool> Photon_pixelSeed
 array<char> Photon_seedGain
 array<int> Photon_genPartIdx
+array<short> Photon_genPartIdx 12.0
 array<char> Photon_genPartFlav
 array<char> Photon_cleanmask
 
@@ -272,6 +299,8 @@ array<short> FsrPhoton_muonIdx 11.9
 array<float> FsrPhoton_phi
 array<float> FsrPhoton_pt
 array<float> FsrPhoton_relIso03
+#nanoAODv12
+array<short> FsrPhoton_electronIdx
 
 ################ AK4 Jets ################
 
@@ -482,9 +511,11 @@ array<float> GenPart_mass
 array<float> GenPart_phi
 array<float> GenPart_pt
 array<int> GenPart_genPartIdxMother
+array<short> GenPart_genPartIdxMother 12.0
 array<int> GenPart_pdgId
 array<int> GenPart_status
 array<int> GenPart_statusFlags
+array<ushort> GenPart_statusFlags 12.0
 
 int nGenDressedLepton
 array<float> GenDressedLepton_eta
@@ -586,7 +617,9 @@ float PV_z
 float PV_chi2
 float PV_score
 int PV_npvs
+uchar PV_npvs 12.0
 int PV_npvsGood
+uchar PV_npvsGood 12.0
 
 ################ Secondary vertices ################
 int nSV

--- a/txt/variables/pico
+++ b/txt/variables/pico
@@ -161,6 +161,8 @@ vector<float> jet_breg_corr
 vector<float> jet_breg_res
 vector<float> jet_deepcsv
 vector<float> jet_deepflav
+vector<float> jet_btagpnetb
+vector<float> jet_btagak4b
 vector<int>   jet_puid
 vector<float> jet_puid_disc
 vector<float> jet_ne_emef
@@ -281,6 +283,7 @@ vector<float> el_dxy
 vector<float> el_ip3d
 vector<float> el_sip3d
 vector<float> el_idmva
+vector<float> el_idmvaHZZ
 vector<bool>  el_id
 vector<bool>  el_id80
 vector<bool>  el_id90
@@ -290,6 +293,7 @@ vector<bool>  el_ispf
 vector<int>   el_charge
 vector<int>   el_pflavor
 vector<bool>  el_ecal
+vector<int>   el_fsrphotonidx
 
 ##################   Di-Leptons   ################
 int nll
@@ -371,6 +375,7 @@ vector<float> fsrphoton_phi
 vector<float> fsrphoton_pt
 vector<float> fsrphoton_reliso
 vector<int>   fsrphoton_muonidx
+vector<int> fsrphoton_electronidx
 
 ###################   Tracks    ##################
 int ntk


### PR DESCRIPTION
Added all the changes in variable type in nanoAOD v12.
Switched to mvaHZZIso for electrons for Run 3 (using WP Summer18UL (https://twiki.cern.ch/twiki/bin/viewauth/CMS/MultivariateElectronIdentificationRun2#HZZ_MVA_training_details_and_wor))
Updated btagging SFs for run 2 & 3. Added PNet btagging for Run 3.