### PR TITLE
Save all gen photon for DY sample. Save some photon_jet variables when there's one signal jet

### DIFF
--- a/inc/mc_producer.hpp
+++ b/inc/mc_producer.hpp
@@ -11,7 +11,7 @@ public:
   explicit GenParticleProducer(int year,float nanoaod_version);
   ~GenParticleProducer();
 
-  void WriteGenParticles(nano_tree &nano, pico_tree &pico);
+  void WriteGenParticles(nano_tree &nano, pico_tree &pico, bool isDY);
   bool IsInteresting(std::vector<int> const & interested_mc_ids, std::vector<std::pair<int, int> > const & interested_mc_ids_range, int mc_id);
 
   int GetFirstCopyIdxOrInterestingIdx(nano_tree & nano, int imc, std::map<int, int> & mc_index_to_interested_index);

--- a/src/mc_producer.cpp
+++ b/src/mc_producer.cpp
@@ -77,7 +77,7 @@ int GenParticleProducer::GetMotherIdx(nano_tree & nano, int imc, map<int, int> &
   return GetFirstCopyIdxOrInterestingIdx(nano, mc_mom_index, mc_index_to_interested_index);
 }
 
-void GenParticleProducer::WriteGenParticles(nano_tree &nano, pico_tree &pico){
+void GenParticleProducer::WriteGenParticles(nano_tree &nano, pico_tree &pico, bool isDY){
 
   // Saves if isPrompt and isFirstCopy
   //                               H, Z,  W, gamma, gluon, b, t, d, u, s, c
@@ -108,6 +108,8 @@ void GenParticleProducer::WriteGenParticles(nano_tree &nano, pico_tree &pico){
     bool lepton_interesting = IsInteresting(interested_lepton_ids, {}, mc_id);
     bool save_index = false;
     bool is_tauDecayProduct = false;
+    // for HZg, save all gen photons for DY sample
+    if (isDY && mc_id == 22) save_index = true;
     if (is_interesting) {
       // 0: isPrompt, 12: isFirstCopy, 
       if (mc_statusFlags[0]==1 && mc_statusFlags[12]==1) save_index = true;

--- a/src/process_nano.cxx
+++ b/src/process_nano.cxx
@@ -304,6 +304,7 @@ int main(int argc, char *argv[]){
   // Other tools
   EventTools event_tools(in_path, year, isData, nanoaod_version);
   int event_type = event_tools.GetEventType();
+  bool isDY = event_type/100 == 62 ? isZgamma : false;
 
   ISRTools isr_tools(in_path, year, nanoaod_version, isData);
 
@@ -407,7 +408,7 @@ int main(int argc, char *argv[]){
 
     if (debug) cout<<"INFO:: Writing gen particles"<<endl;
 
-    if (!isData) mc_producer.WriteGenParticles(nano, pico);
+    if (!isData) mc_producer.WriteGenParticles(nano, pico, isDY);
     isr_tools.WriteISRSystemPt(nano, pico);
 
     if (debug) cout<<"INFO:: Writing jets, MET and ISR vars"<<endl;

--- a/src/zgamma_producer.cpp
+++ b/src/zgamma_producer.cpp
@@ -73,7 +73,9 @@ void ZGammaVarProducer::WriteZGammaVars(nano_tree &nano, pico_tree &pico, vector
       } else if (sig_jet_nano_idx.size() > 0) {
 	TLorentzVector j1;
         j1.SetPtEtaPhiM(nano.Jet_pt()[sig_jet_nano_idx[0]], nano.Jet_eta()[sig_jet_nano_idx[0]], nano.Jet_phi()[sig_jet_nano_idx[0]], nano.Jet_mass()[sig_jet_nano_idx[0]]);
+	pico.out_llphoton_dijet_dphi().push_back(llg.DeltaPhi(j1));
 	pico.out_llphoton_dijet_balance().push_back((dilep+photon+j1).Pt()/(dilep.Pt()+photon.Pt()+j1.Pt()));
+	pico.out_llphoton_dijet_dr().push_back(llg.DeltaR(j1));
 	pico.out_photon_jet1_dr().push_back(photon.DeltaR(j1));
       }
 
@@ -325,6 +327,12 @@ void ZGammaVarProducer::WriteZGammaVars(nano_tree &nano, pico_tree &pico, vector
         pico.out_llphoton_refit_dijet_balance() = (ll_refit+photon+j1+j2).Pt()/(ll_refit.Pt()+photon.Pt()+j1.Pt()+j2.Pt());
         pico.out_llphoton_refit_dijet_dr()      = llg_refit.DeltaR(dijet);
 
+      } else if (sig_jet_nano_idx.size() > 0) {
+	TLorentzVector j1;
+	j1.SetPtEtaPhiM(nano.Jet_pt()[sig_jet_nano_idx[0]], nano.Jet_eta()[sig_jet_nano_idx[0]], nano.Jet_phi()[sig_jet_nano_idx[0]], nano.Jet_mass()[sig_jet_nano_idx[0]]);
+	pico.out_llphoton_refit_dijet_dphi()    = llg_refit.DeltaPhi(j1);
+	pico.out_llphoton_refit_dijet_balance() = (ll_refit+j1).Pt()/(ll_refit.Pt()+photon.Pt()+j1.Pt());
+	pico.out_llphoton_refit_dijet_dr()      = llg_refit.DeltaR(j1);
       }
 
 

--- a/src/zgamma_producer.cpp
+++ b/src/zgamma_producer.cpp
@@ -57,7 +57,6 @@ void ZGammaVarProducer::WriteZGammaVars(nano_tree &nano, pico_tree &pico, vector
       pico.out_llphoton_iph().push_back(igamma);
       pico.out_llphoton_ill().push_back(ill);
 
-
       if(sig_jet_nano_idx.size() > 1) {
         TLorentzVector j1, j2, dijet;
         j1.SetPtEtaPhiM(nano.Jet_pt()[sig_jet_nano_idx[0]], nano.Jet_eta()[sig_jet_nano_idx[0]], nano.Jet_phi()[sig_jet_nano_idx[0]], nano.Jet_mass()[sig_jet_nano_idx[0]]);
@@ -71,7 +70,11 @@ void ZGammaVarProducer::WriteZGammaVars(nano_tree &nano, pico_tree &pico, vector
         pico.out_photon_jet1_dr().push_back(photon.DeltaR(j1));
         pico.out_photon_jet2_dr().push_back(photon.DeltaR(j2));
         pico.out_photon_zeppenfeld().push_back(abs(photon.Eta() - (j1.Eta() + j2.Eta())/2));
-
+      } else if (sig_jet_nano_idx.size() > 0) {
+	TLorentzVector j1;
+        j1.SetPtEtaPhiM(nano.Jet_pt()[sig_jet_nano_idx[0]], nano.Jet_eta()[sig_jet_nano_idx[0]], nano.Jet_phi()[sig_jet_nano_idx[0]], nano.Jet_mass()[sig_jet_nano_idx[0]]);
+	pico.out_llphoton_dijet_balance().push_back((dilep+photon+j1).Pt()/(dilep.Pt()+photon.Pt()+j1.Pt()));
+	pico.out_photon_jet1_dr().push_back(photon.DeltaR(j1));
       }
 
       TVector3 g_pT = photon.Vect();


### PR DESCRIPTION
As stated by title. Two small features:
1. save all gen photons when the sample is DY. This is needed for the private DY samples we generate
2. save some llphoton_dijet/j1 variable when there's only one signal jet (for a quick study I'd like to do for vbf).